### PR TITLE
set VERSION for artifact cache hit

### DIFF
--- a/.github/workflows/build-armbian-matrix.yml
+++ b/.github/workflows/build-armbian-matrix.yml
@@ -101,8 +101,8 @@ jobs:
           mkdir -p build/userpatches/extensions/
           cp -ar armbian/extensions/* build/userpatches/extensions/
           cp -ar armbian/base/*.conf build/userpatches/
-          echo "temp version hack"
-          echo 23.05.0-trunk > build/VERSION
+          echo "short-circuit version for hitting artifact cache for kernel"
+          echo 23.05.1 > build/userpatches/VERSION
       
       - name: Build board ${{ matrix.board }}
         id: buildBoard

--- a/.github/workflows/build-armbian.yml
+++ b/.github/workflows/build-armbian.yml
@@ -93,8 +93,8 @@ jobs:
 
         cp -ar armbian/extensions/* build/userpatches/extensions/
         cp -ar armbian/base/*.conf build/userpatches/
-        echo "temporary hack"
-        echo 23.05.0-trunk > build/VERSION
+        echo "short-circuit version to get artifact cache for kernels"
+        echo 23.05.1 > build/userpatches/VERSION
 
     - name: Compile Armbian
       id: build


### PR DESCRIPTION
override VERSION so release artifacts are hit until armbian cache is rebuilt