### PR TITLE
Offline first boot, NetworkManager Wi-Fi, branded console, and AWCFG config-driven install

### DIFF
--- a/.github/workflows/build-image-simple.yml
+++ b/.github/workflows/build-image-simple.yml
@@ -56,8 +56,9 @@ jobs:
         run: |
           sudo apt-get update
           # qemu/binfmt for the Armbian build; gdisk(sgdisk)+fdisk(sfdisk)+dosfstools
-          # for appending the AWCFG config partition to the built image.
-          sudo apt-get install -y qemu-user-static binfmt-support gdisk fdisk dosfstools
+          # for the AWCFG partition; squashfs-tools + grub-*-bin for the Live USB image.
+          sudo apt-get install -y qemu-user-static binfmt-support gdisk fdisk dosfstools \
+            squashfs-tools grub-efi-amd64-bin grub-pc-bin
 
       - name: Checkout
         uses: actions/checkout@v4
@@ -170,6 +171,150 @@ jobs:
           sudo mkdir -p .armbian-build/output/debs .armbian-build/cache/rootfs .armbian-build/cache/ccache
           sudo chown -R "$(id -u):$(id -g)" \
             .armbian-build/output/debs .armbian-build/cache/rootfs .armbian-build/cache/ccache || true
+
+      # Build the separate x86 "Live USB" image from the embedded rootfs: a
+      # squashfs + live-boot layout that loads the whole OS into RAM (toram) so a
+      # USB I/O-error or unplug doesn't panic. Runs BEFORE the finalize step so
+      # the squashfs captures the rootfs WITH the container tarballs (the finalize
+      # step lean-pre-extracts + removes them from the embedded image afterward).
+      # Reads the embedded image read-only and writes a NEW Airwaves_OS_LiveUSB_*
+      # image; the embedded image is untouched.
+      - name: Build Live USB image (x86, squashfs + live-boot + toram)
+        if: ${{ github.event.inputs.board == 'uefi-x86' }}
+        run: |
+          set -euo pipefail
+          sudo chown -R "$(id -u):$(id -g)" .armbian-build/output/images 2>/dev/null || true
+          cd .armbian-build/output/images 2>/dev/null || { echo "no images dir"; exit 0; }
+          shopt -s nullglob
+          AWCFG="$GITHUB_WORKSPACE/armbian/userpatches/extensions/airwaves-os/config/awcfg"
+
+          # Decompress the embedded image if needed (the finalize step also works
+          # on the .img; leaving it decompressed here is fine).
+          imgs=( *.img ); EMB=""
+          if [ ${#imgs[@]} -gt 0 ]; then EMB="${imgs[0]}"
+          else
+            xzs=( *.img.xz ); [ ${#xzs[@]} -gt 0 ] || { echo "no image"; exit 0; }
+            echo "Decompressing ${xzs[0]} ..."; xz -d -T0 -k "${xzs[0]}"; imgs=( *.img ); EMB="${imgs[0]}"
+            rm -f "${xzs[0]}"
+          fi
+          echo "Embedded image: ${EMB}"
+
+          AWVER="$(sed -nE 's/^version[[:space:]]*=[[:space:]]*"([^"]+)".*/\1/p' \
+            "$GITHUB_WORKSPACE/containers/airwaves-manager/Cargo.toml" | head -1)"
+          case "$GITHUB_REF" in refs/tags/v*) AWVER="${GITHUB_REF#refs/tags/v}" ;; *) AWVER="${AWVER:-dev}-$(git -C "$GITHUB_WORKSPACE" rev-parse --short HEAD)" ;; esac
+
+          WORK="$(mktemp -d)"; mkdir -p "${WORK}/live"
+          # --- read the embedded rootfs (read-only) ---------------------------
+          ELOOP="$(sudo losetup -fP --show "${EMB}")"
+          sudo partprobe "${ELOOP}" 2>/dev/null || true; sudo udevadm settle --timeout=30 2>/dev/null || true
+          ROOTP=""
+          for p in "${ELOOP}"p*; do
+            [ -b "$p" ] || continue
+            case "$(sudo blkid -o value -s TYPE "$p" 2>/dev/null)" in ext4|ext3) ;; *) continue ;; esac
+            m="$(mktemp -d)"
+            if sudo mount -o ro "$p" "$m" 2>/dev/null; then
+              if [ -d "$m/opt/airwaves" ] && [ -d "$m/boot" ]; then ROOTP="$p"; RMNT="$m"; break; fi
+              sudo umount "$m" 2>/dev/null
+            fi
+            rmdir "$m" 2>/dev/null
+          done
+          [ -n "$ROOTP" ] || { echo "::error::could not find embedded rootfs partition"; sudo losetup -d "${ELOOP}"; exit 1; }
+          echo "Embedded rootfs: ${ROOTP}"
+
+          # Kernel + initrd (initrd already includes live-boot via the airwaves-live extension).
+          KVER="$(ls "${RMNT}/boot"/vmlinuz-* 2>/dev/null | sed 's#.*/vmlinuz-##' | sort -V | tail -1)"
+          [ -n "$KVER" ] || { echo "::error::no kernel in embedded /boot"; sudo umount "${RMNT}"; sudo losetup -d "${ELOOP}"; exit 1; }
+          cp "${RMNT}/boot/vmlinuz-${KVER}" "${WORK}/vmlinuz"
+          cp "${RMNT}/boot/initrd.img-${KVER}" "${WORK}/initrd.img"
+
+          # --- squashfs the rootfs (keep the container tarballs; drop docker store) ---
+          echo "Creating squashfs (this takes a few minutes)..."
+          sudo mksquashfs "${RMNT}" "${WORK}/live/filesystem.squashfs" -comp xz -noappend -no-progress \
+            -e proc sys dev run tmp mnt media lost+found \
+               var/lib/docker var/lib/containerd var/lib/docker.hdd var/log.hdd \
+               etc/airwaves/install swapfile
+          sudo chown "$(id -u):$(id -g)" "${WORK}/live/filesystem.squashfs"
+          stat -c %s "${WORK}/live/filesystem.squashfs" > "${WORK}/live/filesystem.size"
+          SQ_BYTES="$(cat "${WORK}/live/filesystem.size")"
+          echo "squashfs: ${SQ_BYTES} bytes"
+          sudo umount "${RMNT}" 2>/dev/null || true; rmdir "${RMNT}" 2>/dev/null || true
+          sudo losetup -d "${ELOOP}"
+
+          # --- assemble the live image ---------------------------------------
+          SQ_MIB=$(( (SQ_BYTES + 1048575) / 1048576 ))
+          LIVE_DATA_MIB=$(( SQ_MIB + 192 ))
+          IMG_MIB=$(( 4 + 260 + LIVE_DATA_MIB + 64 + 2 ))
+          LIVE="Airwaves_OS_LiveUSB_${AWVER}_x86_UEFI_${{ github.event.inputs.release }}.img"
+          echo "Live image: ${LIVE} (${IMG_MIB} MiB)"
+          rm -f "${LIVE}"; truncate -s "${IMG_MIB}M" "${LIVE}"
+          # GPT: BIOS-boot 4M + ESP 260M + LIVE-DATA + AWCFG 64M.
+          sudo sgdisk -og \
+            -n 1:0:+4M   -t 1:EF02 -c 1:"BIOS-BOOT" \
+            -n 2:0:+260M -t 2:EF00 -c 2:"AIRWAVES_EFI" \
+            -n 3:0:+${LIVE_DATA_MIB}M -t 3:8300 -c 3:"AIRWAVES_LIVE" \
+            -n 4:0:0     -t 4:0700 -c 4:"AWCFG" "${LIVE}"
+
+          LLOOP="$(sudo losetup -fP --show "${LIVE}")"
+          sudo partprobe "${LLOOP}" 2>/dev/null || true; sudo udevadm settle --timeout=30 2>/dev/null || true
+          for n in 2 3 4; do for _ in $(seq 1 15); do [ -b "${LLOOP}p${n}" ] && break; sudo udevadm settle --timeout=5 2>/dev/null || true; sleep 1; done; done
+          sudo mkfs.fat -F32 -n AIRWAVES_EFI "${LLOOP}p2" >/dev/null
+          sudo mkfs.ext4 -q -L AIRWAVES_LIVE "${LLOOP}p3"
+          sudo mkfs.fat -F32 -n AWCFG "${LLOOP}p4" >/dev/null
+
+          ESP="$(mktemp -d)"; sudo mount "${LLOOP}p2" "${ESP}"
+          sudo mkdir -p "${ESP}/boot"
+          sudo grub-install --target=x86_64-efi --efi-directory="${ESP}" --boot-directory="${ESP}/boot" \
+            --removable --no-nvram --recheck 2>&1 | tail -3
+          sudo grub-install --target=i386-pc --boot-directory="${ESP}/boot" --recheck "${LLOOP}" 2>&1 | tail -3
+          sudo cp "${WORK}/vmlinuz" "${ESP}/boot/vmlinuz"
+          sudo cp "${WORK}/initrd.img" "${ESP}/boot/initrd.img"
+          CMN="boot=live live-media=LABEL=AIRWAVES_LIVE ignore_uuid nocomponents console=tty0 console=ttyS0,115200"
+          # Heredoc body is indented to the YAML block level; YAML strips that
+          # back to column 0 so the shell sees a normal <<GRUBCFG heredoc.
+          sudo tee "${ESP}/boot/grub/grub.cfg" >/dev/null <<GRUBCFG
+          insmod part_gpt
+          insmod fat
+          insmod ext2
+          insmod search_label
+          set timeout=5
+          set default=0
+          menuentry "Airwaves OS (Live - auto RAM)" {
+              search --no-floppy --label --set=root AIRWAVES_EFI
+              linux /boot/vmlinuz ${CMN}
+              initrd /boot/initrd.img
+          }
+          menuentry "Airwaves OS (Live - Load to RAM)" {
+              search --no-floppy --label --set=root AIRWAVES_EFI
+              linux /boot/vmlinuz ${CMN} toram
+              initrd /boot/initrd.img
+          }
+          menuentry "Airwaves OS (Live - Run from USB)" {
+              search --no-floppy --label --set=root AIRWAVES_EFI
+              linux /boot/vmlinuz ${CMN} notoram
+              initrd /boot/initrd.img
+          }
+          GRUBCFG
+          grep -q initrd "${ESP}/boot/grub/grub.cfg" || { echo "::error::live grub.cfg missing initrd"; exit 1; }
+          grep -q '/dev/' "${ESP}/boot/grub/grub.cfg" && { echo "::error::live grub.cfg has /dev path"; exit 1; }
+          sudo umount "${ESP}"; rmdir "${ESP}" 2>/dev/null || true
+
+          LDATA="$(mktemp -d)"; sudo mount "${LLOOP}p3" "${LDATA}"
+          sudo mkdir -p "${LDATA}/live"
+          sudo cp "${WORK}/live/filesystem.squashfs" "${LDATA}/live/"
+          sudo cp "${WORK}/live/filesystem.size" "${LDATA}/live/"
+          sync; sudo umount "${LDATA}"; rmdir "${LDATA}" 2>/dev/null || true
+
+          AWMP="$(mktemp -d)"; sudo mount "${LLOOP}p4" "${AWMP}"
+          sudo cp "${AWCFG}/airwaves-install.json" "${AWMP}/airwaves-install.json"
+          sudo cp "${AWCFG}/README.txt" "${AWMP}/README.txt"
+          sync; sudo umount "${AWMP}"; rmdir "${AWMP}" 2>/dev/null || true
+
+          sudo losetup -d "${LLOOP}"
+          echo "Compressing ${LIVE} ..."
+          xz -z -T0 -f "${LIVE}"
+          sudo chown -R "$(id -u):$(id -g)" . 2>/dev/null || true
+          rm -rf "${WORK}"
+          ls -lh Airwaves_OS_LiveUSB_*.img.xz
 
       # Append the AWCFG config partition (FAT32, label AWCFG) as the LAST
       # partition of the built image. It carries airwaves-install.json + README,
@@ -332,6 +477,9 @@ jobs:
           echo "Airwaves version for filename: ${AWVER}"
           shopt -s nullglob
           for f in Airwaves_OS_*.img.xz Airwaves_OS_*.img; do
+            # The Live USB image is already named with the version; skip it (its
+            # first field is "LiveUSB", not a REVISION to replace).
+            case "$f" in *LiveUSB*) continue;; esac
             rest="${f#Airwaves_OS_}"        # <REVISION>_<board>_...
             tail="${rest#*_}"              # <board>_...  (drops the REVISION field)
             new="Airwaves_OS_${AWVER}_${tail}"

--- a/.github/workflows/build-image-simple.yml
+++ b/.github/workflows/build-image-simple.yml
@@ -268,7 +268,11 @@ jobs:
           sudo grub-install --target=i386-pc --boot-directory="${ESP}/boot" --recheck "${LLOOP}" 2>&1 | tail -3
           sudo cp "${WORK}/vmlinuz" "${ESP}/boot/vmlinuz"
           sudo cp "${WORK}/initrd.img" "${ESP}/boot/initrd.img"
-          CMN="boot=live live-media=LABEL=AIRWAVES_LIVE ignore_uuid nocomponents console=tty0 console=ttyS0,115200"
+          # No live-media= here: it expects a DEVICE (not LABEL=), and a bad value
+          # makes live-boot search nothing ("Unable to find a medium"). Let live-boot
+          # auto-scan all partitions for /live/filesystem.squashfs — only the live
+          # USB carries it.
+          CMN="boot=live ignore_uuid nocomponents console=tty0 console=ttyS0,115200"
           # Heredoc body is indented to the YAML block level; YAML strips that
           # back to column 0 so the shell sees a normal <<GRUBCFG heredoc.
           sudo tee "${ESP}/boot/grub/grub.cfg" >/dev/null <<GRUBCFG

--- a/.github/workflows/build-image-simple.yml
+++ b/.github/workflows/build-image-simple.yml
@@ -177,7 +177,7 @@ jobs:
       # table), and is consumed at first setup / via an apply.conf trigger by
       # airwaves-preconfig. Handles both GPT (x86/rockchip) and MBR (Pi) tables,
       # and never touches the existing partitions or the rockchip raw u-boot area.
-      - name: Add AWCFG config partition
+      - name: Pre-extract containers + add AWCFG config partition
         run: |
           set -euo pipefail
           sudo chown -R "$(id -u):$(id -g)" .armbian-build/output/images 2>/dev/null || true
@@ -239,6 +239,65 @@ jobs:
           done
           [ -b "${PART}" ] || { echo "::error::AWCFG partition node ${PART} not found"; sudo losetup -d "${LOOP}"; exit 1; }
           echo "AWCFG partition node: ${PART} (last of ${NPARTS} partitions)"
+
+          # --- Pre-extract containers into the image's docker store (lean) ------
+          # `docker load` of the ~100 MB tarballs on first boot is slow on cheap
+          # USB media (it re-writes every layer). Do it here: run a throwaway
+          # dockerd against the image's /var/lib/docker, load the baked tarballs,
+          # and on success delete them so first boot just runs. Fully guarded in a
+          # `set +e` subshell — any failure leaves the tarballs in place so the
+          # device still loads them on first boot (never ships with neither).
+          (
+            set +e
+            command -v dockerd >/dev/null 2>&1 || { echo "::warning::dockerd absent; keeping tarballs"; exit 0; }
+            ROOTMNT="";
+            for cand in $(seq 1 "$NPARTS"); do
+              [ "$cand" -eq "$NPARTS" ] && continue          # skip the new AWCFG partition
+              dev="${LOOP}p${cand}"; [ -b "$dev" ] || continue
+              case "$(sudo blkid -o value -s TYPE "$dev" 2>/dev/null)" in ext4|ext3|ext2) ;; *) continue ;; esac
+              m="$(mktemp -d)"
+              if sudo mount "$dev" "$m" 2>/dev/null; then
+                if ls "$m"/opt/airwaves/images/*.tar >/dev/null 2>&1; then ROOTMNT="$m"; break; fi
+                sudo umount "$m" 2>/dev/null
+              fi
+              rmdir "$m" 2>/dev/null
+            done
+            [ -n "$ROOTMNT" ] || { echo "::warning::no rootfs with baked tarballs; skipping pre-extract"; exit 0; }
+            echo "Pre-extracting containers into $(basename "$ROOTMNT")/var/lib/docker"
+            # Free the runner's docker so our throwaway daemon owns the namespace.
+            sudo systemctl stop docker.service docker.socket containerd.service 2>/dev/null
+            sudo mkdir -p "$ROOTMNT/var/lib/docker"
+            SOCK=/tmp/aw-preload.sock; PIDF=/tmp/aw-preload.pid
+            sudo dockerd --data-root="$ROOTMNT/var/lib/docker" --exec-root=/tmp/aw-preload-exec \
+              --host="unix://$SOCK" --pidfile="$PIDF" --iptables=false --bridge=none \
+              --storage-driver=overlay2 >/tmp/aw-preload-dockerd.log 2>&1 &
+            up=0; for _ in $(seq 1 40); do sudo docker --host="unix://$SOCK" info >/dev/null 2>&1 && { up=1; break; }; sleep 1; done
+            loaded=1
+            if [ "$up" = 1 ]; then
+              for t in "$ROOTMNT"/opt/airwaves/images/*.tar; do
+                echo "  loading $(basename "$t")"
+                sudo docker --host="unix://$SOCK" load -i "$t" || loaded=0
+              done
+              sudo docker --host="unix://$SOCK" images
+            else
+              loaded=0; echo "::warning::transient dockerd failed to start"; cat /tmp/aw-preload-dockerd.log 2>/dev/null | tail -20
+            fi
+            # Stop the throwaway daemon and let it flush the store before unmount.
+            sudo kill "$(sudo cat "$PIDF" 2>/dev/null)" 2>/dev/null
+            for _ in $(seq 1 20); do sudo docker --host="unix://$SOCK" info >/dev/null 2>&1 || break; sleep 1; done
+            sudo pkill -f "data-root=$ROOTMNT/var/lib/docker" 2>/dev/null
+            sleep 2
+            if [ "$loaded" = 1 ]; then
+              echo "  pre-extract OK — removing tarballs (lean)"
+              sudo rm -f "$ROOTMNT"/opt/airwaves/images/*.tar
+            else
+              echo "::warning::container pre-extract failed; keeping tarballs for first-boot load"
+            fi
+            sync
+            sudo umount "$ROOTMNT" 2>/dev/null || sudo umount -l "$ROOTMNT" 2>/dev/null
+            rmdir "$ROOTMNT" 2>/dev/null
+          ) || true
+          # ---------------------------------------------------------------------
 
           sudo mkfs.vfat -F 32 -n AWCFG "${PART}"
           MP="$(mktemp -d)"

--- a/.github/workflows/build-image-simple.yml
+++ b/.github/workflows/build-image-simple.yml
@@ -30,6 +30,11 @@ on:
           - vendor
           - legacy
           - edge
+      bundle_containers:
+        description: "Bake the release's manager+gateway containers into the image (offline first boot)"
+        required: true
+        default: true
+        type: boolean
 
 # The Armbian build framework tag is pinned in armbian/build.sh (single source
 # of truth); this workflow invokes build.sh, so no override is needed here.
@@ -74,6 +79,72 @@ jobs:
           restore-keys: |
             armbian-${{ github.event.inputs.board }}-${{ github.event.inputs.release }}-${{ github.event.inputs.branch }}-
             armbian-${{ github.event.inputs.board }}-${{ github.event.inputs.release }}-
+
+      # Bake the release's manager+gateway container images INTO the rootfs so the
+      # device's FIRST boot needs no network. Without this, first boot can't pull
+      # the containers when there's no connectivity, so the manager/web UI never
+      # comes up and even Wi-Fi setup is impossible (chicken-and-egg). We pull the
+      # exact images pinned in releases/stable.json at the board's CPU arch, tag
+      # them with the version + channel alias + :latest, and docker-save each into
+      # the userpatches images/ dir, which the airwaves-base extension copies into
+      # the image and airwaves-init loads on first boot. Runs AFTER the cache step
+      # so the tarballs never perturb the kernel/rootfs cache key.
+      - name: Bundle release containers (offline first boot)
+        if: ${{ inputs.bundle_containers }}
+        env:
+          BOARD: ${{ github.event.inputs.board }}
+          GHCR_USER: ${{ github.actor }}
+          GHCR_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          set -euo pipefail
+          REL="releases/stable.json"
+          [ -f "$REL" ] || { echo "::error::$REL not found"; exit 1; }
+
+          CHANNEL="$(jq -r '.channel // "stable"' "$REL")"
+          OSVER="$(jq -r '.os_version // empty' "$REL")"
+          MGR_IMG="$(jq -r '.components.manager.image' "$REL")"
+          MGR_TAG="$(jq -r '.components.manager.tag' "$REL")"
+          GW_IMG="$(jq -r '.components.gateway.image' "$REL")"
+          GW_TAG="$(jq -r '.components.gateway.tag' "$REL")"
+          for v in "$CHANNEL" "$MGR_IMG" "$MGR_TAG" "$GW_IMG" "$GW_TAG"; do
+            [ -n "$v" ] && [ "$v" != "null" ] || { echo "::error::missing field in $REL"; exit 1; }
+          done
+
+          case "$BOARD" in
+            uefi-x86) PLAT="linux/amd64" ;;
+            *)        PLAT="linux/arm64" ;;
+          esac
+          echo "channel=$CHANNEL os_version=${OSVER:-?} platform=$PLAT"
+          echo "manager=${MGR_IMG}:${MGR_TAG}  gateway=${GW_IMG}:${GW_TAG}"
+
+          echo "$GHCR_TOKEN" | docker login ghcr.io -u "$GHCR_USER" --password-stdin
+
+          OUT="armbian/userpatches/extensions/airwaves-os/images"
+          mkdir -p "$OUT"
+
+          # Pull the exact pinned image for this arch, then attach the moving tags
+          # the device may reference (channel alias + :latest) so the loaded image
+          # satisfies the compose file offline regardless of which tag it pins.
+          bundle() {
+            local img="$1" tag="$2" svc="$3"
+            echo "==> Pulling ${img}:${tag} (${PLAT})"
+            docker pull --platform "$PLAT" "${img}:${tag}"
+            docker tag "${img}:${tag}" "${img}:${CHANNEL}"
+            docker tag "${img}:${tag}" "${img}:latest"
+            echo "==> Saving ${svc} -> ${OUT}/airwaves-${svc}.tar"
+            docker save -o "${OUT}/airwaves-${svc}.tar" \
+              "${img}:${tag}" "${img}:${CHANNEL}" "${img}:latest"
+          }
+
+          bundle "$MGR_IMG" "$MGR_TAG" "manager"
+          bundle "$GW_IMG" "$GW_TAG" "gateway"
+
+          # Reclaim docker's overlay storage before the heavy Armbian build; the
+          # tarballs we just wrote to disk are what matter from here on.
+          docker image prune -af >/dev/null 2>&1 || true
+          ls -lh "$OUT"/*.tar
+          df -h /
+          echo "Bundled ${CHANNEL} (${OSVER:-?}) containers for ${PLAT}"
 
       - name: Build image
         env:

--- a/.github/workflows/build-image-simple.yml
+++ b/.github/workflows/build-image-simple.yml
@@ -227,12 +227,16 @@ jobs:
           cp "${RMNT}/boot/vmlinuz-${KVER}" "${WORK}/vmlinuz"
           cp "${RMNT}/boot/initrd.img-${KVER}" "${WORK}/initrd.img"
 
-          # --- squashfs the rootfs (keep the container tarballs; drop docker store) ---
+          # --- squashfs the rootfs ---------------------------------------------
+          # Keep the container tarballs (live loads them into RAM) AND the empty
+          # mount-point dirs (/proc /sys /dev /run /tmp /var/lib/docker) — excluding
+          # those removes the directories the initramfs bind-mounts onto, which
+          # panics init ("/root/dev: mount point does not exist"). /var/lib/docker
+          # is empty at this stage (pre-extract runs later) so it costs nothing.
+          # Only drop genuine junk.
           echo "Creating squashfs (this takes a few minutes)..."
           sudo mksquashfs "${RMNT}" "${WORK}/live/filesystem.squashfs" -comp xz -noappend -no-progress \
-            -e proc sys dev run tmp mnt media lost+found \
-               var/lib/docker var/lib/containerd var/lib/docker.hdd var/log.hdd \
-               etc/airwaves/install swapfile
+            -e lost+found swapfile var/swap var/log.hdd var/lib/docker.hdd
           sudo chown "$(id -u):$(id -g)" "${WORK}/live/filesystem.squashfs"
           stat -c %s "${WORK}/live/filesystem.squashfs" > "${WORK}/live/filesystem.size"
           SQ_BYTES="$(cat "${WORK}/live/filesystem.size")"

--- a/.github/workflows/build-image-simple.yml
+++ b/.github/workflows/build-image-simple.yml
@@ -250,14 +250,14 @@ jobs:
           # GPT: BIOS-boot 4M + ESP 260M + LIVE-DATA + AWCFG 64M.
           sudo sgdisk -og \
             -n 1:0:+4M   -t 1:EF02 -c 1:"BIOS-BOOT" \
-            -n 2:0:+260M -t 2:EF00 -c 2:"AIRWAVES_EFI" \
+            -n 2:0:+260M -t 2:EF00 -c 2:"AIRWAVESEFI" \
             -n 3:0:+${LIVE_DATA_MIB}M -t 3:8300 -c 3:"AIRWAVES_LIVE" \
             -n 4:0:0     -t 4:0700 -c 4:"AWCFG" "${LIVE}"
 
           LLOOP="$(sudo losetup -fP --show "${LIVE}")"
           sudo partprobe "${LLOOP}" 2>/dev/null || true; sudo udevadm settle --timeout=30 2>/dev/null || true
           for n in 2 3 4; do for _ in $(seq 1 15); do [ -b "${LLOOP}p${n}" ] && break; sudo udevadm settle --timeout=5 2>/dev/null || true; sleep 1; done; done
-          sudo mkfs.fat -F32 -n AIRWAVES_EFI "${LLOOP}p2" >/dev/null
+          sudo mkfs.fat -F32 -n AIRWAVESEFI "${LLOOP}p2" >/dev/null
           sudo mkfs.ext4 -q -L AIRWAVES_LIVE "${LLOOP}p3"
           sudo mkfs.fat -F32 -n AWCFG "${LLOOP}p4" >/dev/null
 
@@ -279,17 +279,17 @@ jobs:
           set timeout=5
           set default=0
           menuentry "Airwaves OS (Live - auto RAM)" {
-              search --no-floppy --label --set=root AIRWAVES_EFI
+              search --no-floppy --label --set=root AIRWAVESEFI
               linux /boot/vmlinuz ${CMN}
               initrd /boot/initrd.img
           }
           menuentry "Airwaves OS (Live - Load to RAM)" {
-              search --no-floppy --label --set=root AIRWAVES_EFI
+              search --no-floppy --label --set=root AIRWAVESEFI
               linux /boot/vmlinuz ${CMN} toram
               initrd /boot/initrd.img
           }
           menuentry "Airwaves OS (Live - Run from USB)" {
-              search --no-floppy --label --set=root AIRWAVES_EFI
+              search --no-floppy --label --set=root AIRWAVESEFI
               linux /boot/vmlinuz ${CMN} notoram
               initrd /boot/initrd.img
           }

--- a/.github/workflows/build-image-simple.yml
+++ b/.github/workflows/build-image-simple.yml
@@ -55,7 +55,9 @@ jobs:
       - name: Install dependencies
         run: |
           sudo apt-get update
-          sudo apt-get install -y qemu-user-static binfmt-support
+          # qemu/binfmt for the Armbian build; gdisk(sgdisk)+fdisk(sfdisk)+dosfstools
+          # for appending the AWCFG config partition to the built image.
+          sudo apt-get install -y qemu-user-static binfmt-support gdisk fdisk dosfstools
 
       - name: Checkout
         uses: actions/checkout@v4
@@ -168,6 +170,90 @@ jobs:
           sudo mkdir -p .armbian-build/output/debs .armbian-build/cache/rootfs .armbian-build/cache/ccache
           sudo chown -R "$(id -u):$(id -g)" \
             .armbian-build/output/debs .armbian-build/cache/rootfs .armbian-build/cache/ccache || true
+
+      # Append the AWCFG config partition (FAT32, label AWCFG) as the LAST
+      # partition of the built image. It carries airwaves-install.json + README,
+      # is editable on any OS, survives dd-flash (it's recorded in the partition
+      # table), and is consumed at first setup / via an apply.conf trigger by
+      # airwaves-preconfig. Handles both GPT (x86/rockchip) and MBR (Pi) tables,
+      # and never touches the existing partitions or the rockchip raw u-boot area.
+      - name: Add AWCFG config partition
+        run: |
+          set -euo pipefail
+          sudo chown -R "$(id -u):$(id -g)" .armbian-build/output/images 2>/dev/null || true
+          cd .armbian-build/output/images 2>/dev/null || { echo "no images dir"; exit 0; }
+          shopt -s nullglob
+          PAYLOAD="$GITHUB_WORKSPACE/armbian/userpatches/extensions/airwaves-os/config/awcfg"
+          [ -f "${PAYLOAD}/airwaves-install.json" ] || { echo "::error::AWCFG payload missing"; exit 1; }
+
+          # Work on an uncompressed .img; decompress the .xz if that's all we have.
+          imgs=( *.img )
+          if [ ${#imgs[@]} -gt 0 ]; then
+            IMG="${imgs[0]}"
+            rm -f "${IMG}.xz" "${IMG}.xz.sha" "${IMG}.sha"   # stale; regenerated below
+          else
+            xzs=( *.img.xz )
+            [ ${#xzs[@]} -gt 0 ] || { echo "no image to modify"; exit 0; }
+            echo "Decompressing ${xzs[0]} ..."
+            xz -d -T0 "${xzs[0]}"
+            imgs=( *.img ); IMG="${imgs[0]}"
+          fi
+          echo "Appending AWCFG to ${IMG}"
+
+          # -p = low-level probe (reads the table from the file itself); without
+          # it blkid uses its cache and returns empty for a plain .img, which
+          # would send GPT images down the MBR branch and corrupt the GPT.
+          PTTYPE="$(sudo blkid -p -o value -s PTTYPE "${IMG}" 2>/dev/null || echo)"
+          echo "Partition table type: ${PTTYPE:-unknown}"
+
+          # Grow the image to make room (64 MiB partition + alignment/secondary GPT).
+          truncate -s +68M "${IMG}"
+
+          case "${PTTYPE}" in
+            gpt)
+              sudo sgdisk -e "${IMG}"                                   # move backup GPT to new end
+              sudo sgdisk --new=0:0:+64M --typecode=0:0700 --change-name=0:AWCFG "${IMG}"
+              ;;
+            dos|"")
+              # MBR (Pi) or undetected: append a primary FAT32-LBA partition.
+              echo ',64M,c' | sudo sfdisk --append "${IMG}"
+              ;;
+            *)
+              echo "::error::unsupported partition table '${PTTYPE}'"; exit 1 ;;
+          esac
+
+          LOOP="$(sudo losetup -fP --show "${IMG}")"
+          echo "Loop device: ${LOOP}"
+          sudo partprobe "${LOOP}" 2>/dev/null || true
+          sudo udevadm settle --timeout=30 2>/dev/null || true
+          # AWCFG is the LAST partition. Target that EXACT node from the on-disk
+          # table count — do NOT grab the first node that appears, which could be
+          # the ESP/firmware (mkfs on it would destroy the image).
+          NPARTS="$(sudo partx -g "${IMG}" 2>/dev/null | wc -l | tr -d ' ')"
+          [ "${NPARTS:-0}" -ge 1 ] || { echo "::error::could not read partition table from ${IMG}"; sudo losetup -d "${LOOP}"; exit 1; }
+          PART="${LOOP}p${NPARTS}"
+          for _ in $(seq 1 15); do
+            [ -b "${PART}" ] && break
+            sudo udevadm settle --timeout=5 2>/dev/null || true
+            sleep 1
+          done
+          [ -b "${PART}" ] || { echo "::error::AWCFG partition node ${PART} not found"; sudo losetup -d "${LOOP}"; exit 1; }
+          echo "AWCFG partition node: ${PART} (last of ${NPARTS} partitions)"
+
+          sudo mkfs.vfat -F 32 -n AWCFG "${PART}"
+          MP="$(mktemp -d)"
+          sudo mount "${PART}" "${MP}"
+          sudo cp "${PAYLOAD}/airwaves-install.json" "${MP}/airwaves-install.json"
+          sudo cp "${PAYLOAD}/README.txt" "${MP}/README.txt"
+          sync
+          sudo umount "${MP}"
+          sudo losetup -d "${LOOP}"
+          rmdir "${MP}" 2>/dev/null || true
+
+          echo "Recompressing ${IMG} ..."
+          xz -z -T0 -f "${IMG}"
+          sudo chown -R "$(id -u):$(id -g)" . 2>/dev/null || true
+          ls -lh
 
       # Stamp the Airwaves OS version into the image filename. We can't do this
       # via Armbian's REVISION (it feeds base-files' package version, which must

--- a/.github/workflows/build-os-image.yml
+++ b/.github/workflows/build-os-image.yml
@@ -200,55 +200,10 @@ jobs:
           clean: false
           path: userpatches.repo
 
-      # Bake the release's manager+gateway container images INTO the userpatches
-      # extension's images/ dir so the next "Install userpatches" rsync carries
-      # them into the build and airwaves-base copies them onto the image. Without
-      # this the device's FIRST boot finds no pre-baked tarballs and must pull
-      # from the registry, which fails with no network (the manager/web UI never
-      # comes up and even Wi-Fi setup is impossible) — exactly the field report.
-      # The production OS image previously skipped this entirely (only the manual
-      # build-image-simple workflow baked containers). Runs BEFORE the rm of
-      # userpatches.repo so releases/stable.json is still present.
-      - name: Bundle release containers (offline first boot)
-        if: ${{ github.event.inputs.bundleContainers != 'no' }}
-        env:
-          INVOCATION: ${{ matrix.invocation }}
-        run: |
-          set -euo pipefail
-          REL="userpatches.repo/releases/stable.json"
-          if [ ! -f "$REL" ]; then
-            echo "::warning::$REL not found; image will pull containers on first boot (needs network)"
-            exit 0
-          fi
-          BOARD="$(printf '%s' "$INVOCATION" | grep -oE 'BOARD=[A-Za-z0-9._-]+' | head -1 | cut -d= -f2)"
-          case "$BOARD" in
-            uefi-x86) PLAT="linux/amd64" ;;
-            *)        PLAT="linux/arm64" ;;
-          esac
-          CHANNEL="$(jq -r '.channel // "stable"' "$REL")"
-          MGR_IMG="$(jq -r '.components.manager.image' "$REL")"; MGR_TAG="$(jq -r '.components.manager.tag' "$REL")"
-          GW_IMG="$(jq -r '.components.gateway.image' "$REL")";  GW_TAG="$(jq -r '.components.gateway.tag' "$REL")"
-          for v in "$CHANNEL" "$MGR_IMG" "$MGR_TAG" "$GW_IMG" "$GW_TAG"; do
-            [ -n "$v" ] && [ "$v" != "null" ] || { echo "::error::missing field in $REL"; exit 1; }
-          done
-          echo "board=$BOARD platform=$PLAT channel=$CHANNEL"
-          echo "manager=${MGR_IMG}:${MGR_TAG}  gateway=${GW_IMG}:${GW_TAG}"
-          OUT="userpatches.repo/${{ env.USERPATCHES_DIR }}/extensions/airwaves-os/images"
-          mkdir -p "$OUT"
-          bundle() {
-            local img="$1" tag="$2" svc="$3"
-            echo "==> Pull ${img}:${tag} (${PLAT}); save -> ${OUT}/airwaves-${svc}.tar"
-            docker pull --platform "$PLAT" "${img}:${tag}"
-            docker tag "${img}:${tag}" "${img}:${CHANNEL}"
-            docker tag "${img}:${tag}" "${img}:latest"
-            docker save -o "${OUT}/airwaves-${svc}.tar" \
-              "${img}:${tag}" "${img}:${CHANNEL}" "${img}:latest"
-          }
-          bundle "$MGR_IMG" "$MGR_TAG" "manager"
-          bundle "$GW_IMG"  "$GW_TAG"  "gateway"
-          docker image prune -af >/dev/null 2>&1 || true
-          ls -lh "$OUT"/*.tar
-
+      # NOTE: container bundling happens in the build-images job (at image
+      # assembly), not here. The rootfs artifact is content-hashed and may be a
+      # cache hit, so baking into it can't guarantee fresh/offline containers in
+      # the final image; the image job bakes + overlays them instead.
       - name: Install userpatches
         env:
           EXTRA_PARAMS: ${{ env.INPUT_EXTRA_PARAMS }}
@@ -306,6 +261,58 @@ jobs:
           fetch-depth: ${{ matrix.fdepth }}
           clean: false
           path: userpatches.repo
+
+      # Bake the release's manager+gateway container images so the device's FIRST
+      # boot needs no network. Done at IMAGE assembly (not the rootfs artifact):
+      # the generated tarballs aren't in Armbian's content hash, so a cached
+      # rootfs could lack/stale them. airwaves-base overlays these onto the final
+      # image via its pre_umount_final_image hook, so the image always carries
+      # fresh containers regardless of artifact caching. Runs BEFORE the rm of
+      # userpatches.repo (releases/stable.json must still be present). The job's
+      # "Docker Login to GHCR" step above authenticates the pulls.
+      - name: Bundle release containers (offline first boot)
+        env:
+          INVOCATION: ${{ matrix.invocation }}
+        run: |
+          set -euo pipefail
+          REL="userpatches.repo/releases/stable.json"
+          if [ ! -f "$REL" ]; then
+            echo "::warning::$REL not found; image will pull containers on first boot (needs network)"
+            exit 0
+          fi
+          BOARD="$(printf '%s' "$INVOCATION" | grep -oE 'BOARD=[A-Za-z0-9._-]+' | head -1 | cut -d= -f2)"
+          # Fail loudly rather than guess the arch: an empty BOARD would silently
+          # default to arm64 and bake the wrong-arch containers into the image.
+          [ -n "$BOARD" ] || { echo "::error::could not determine BOARD from invocation '$INVOCATION'"; exit 1; }
+          case "$BOARD" in
+            uefi-x86) PLAT="linux/amd64" ;;
+            *)        PLAT="linux/arm64" ;;
+          esac
+          CHANNEL="$(jq -r '.channel // "stable"' "$REL")"
+          MGR_IMG="$(jq -r '.components.manager.image' "$REL")"; MGR_TAG="$(jq -r '.components.manager.tag' "$REL")"
+          GW_IMG="$(jq -r '.components.gateway.image' "$REL")";  GW_TAG="$(jq -r '.components.gateway.tag' "$REL")"
+          for v in "$CHANNEL" "$MGR_IMG" "$MGR_TAG" "$GW_IMG" "$GW_TAG"; do
+            [ -n "$v" ] && [ "$v" != "null" ] || { echo "::error::missing field in $REL"; exit 1; }
+          done
+          echo "board=$BOARD platform=$PLAT channel=$CHANNEL"
+          echo "manager=${MGR_IMG}:${MGR_TAG}  gateway=${GW_IMG}:${GW_TAG}"
+          OUT="userpatches.repo/${{ env.USERPATCHES_DIR }}/extensions/airwaves-os/images"
+          mkdir -p "$OUT"
+          bundle() {
+            local img="$1" tag="$2" svc="$3"
+            echo "==> Pull ${img}:${tag} (${PLAT}); save -> ${OUT}/airwaves-${svc}.tar"
+            docker pull --platform "$PLAT" "${img}:${tag}"
+            docker tag "${img}:${tag}" "${img}:${CHANNEL}"
+            docker tag "${img}:${tag}" "${img}:latest"
+            docker save -o "${OUT}/airwaves-${svc}.tar" \
+              "${img}:${tag}" "${img}:${CHANNEL}" "${img}:latest"
+          }
+          bundle "$MGR_IMG" "$MGR_TAG" "manager"
+          bundle "$GW_IMG"  "$GW_TAG"  "gateway"
+          # NOTE: no `docker image prune` here — this runs on a persistent
+          # self-hosted runner where pruning would evict the Armbian base images
+          # and disrupt parallel matrix jobs.
+          ls -lh "$OUT"/*.tar
 
       - name: Install userpatches
         run: |

--- a/.github/workflows/build-os-image.yml
+++ b/.github/workflows/build-os-image.yml
@@ -200,6 +200,55 @@ jobs:
           clean: false
           path: userpatches.repo
 
+      # Bake the release's manager+gateway container images INTO the userpatches
+      # extension's images/ dir so the next "Install userpatches" rsync carries
+      # them into the build and airwaves-base copies them onto the image. Without
+      # this the device's FIRST boot finds no pre-baked tarballs and must pull
+      # from the registry, which fails with no network (the manager/web UI never
+      # comes up and even Wi-Fi setup is impossible) — exactly the field report.
+      # The production OS image previously skipped this entirely (only the manual
+      # build-image-simple workflow baked containers). Runs BEFORE the rm of
+      # userpatches.repo so releases/stable.json is still present.
+      - name: Bundle release containers (offline first boot)
+        if: ${{ github.event.inputs.bundleContainers != 'no' }}
+        env:
+          INVOCATION: ${{ matrix.invocation }}
+        run: |
+          set -euo pipefail
+          REL="userpatches.repo/releases/stable.json"
+          if [ ! -f "$REL" ]; then
+            echo "::warning::$REL not found; image will pull containers on first boot (needs network)"
+            exit 0
+          fi
+          BOARD="$(printf '%s' "$INVOCATION" | grep -oE 'BOARD=[A-Za-z0-9._-]+' | head -1 | cut -d= -f2)"
+          case "$BOARD" in
+            uefi-x86) PLAT="linux/amd64" ;;
+            *)        PLAT="linux/arm64" ;;
+          esac
+          CHANNEL="$(jq -r '.channel // "stable"' "$REL")"
+          MGR_IMG="$(jq -r '.components.manager.image' "$REL")"; MGR_TAG="$(jq -r '.components.manager.tag' "$REL")"
+          GW_IMG="$(jq -r '.components.gateway.image' "$REL")";  GW_TAG="$(jq -r '.components.gateway.tag' "$REL")"
+          for v in "$CHANNEL" "$MGR_IMG" "$MGR_TAG" "$GW_IMG" "$GW_TAG"; do
+            [ -n "$v" ] && [ "$v" != "null" ] || { echo "::error::missing field in $REL"; exit 1; }
+          done
+          echo "board=$BOARD platform=$PLAT channel=$CHANNEL"
+          echo "manager=${MGR_IMG}:${MGR_TAG}  gateway=${GW_IMG}:${GW_TAG}"
+          OUT="userpatches.repo/${{ env.USERPATCHES_DIR }}/extensions/airwaves-os/images"
+          mkdir -p "$OUT"
+          bundle() {
+            local img="$1" tag="$2" svc="$3"
+            echo "==> Pull ${img}:${tag} (${PLAT}); save -> ${OUT}/airwaves-${svc}.tar"
+            docker pull --platform "$PLAT" "${img}:${tag}"
+            docker tag "${img}:${tag}" "${img}:${CHANNEL}"
+            docker tag "${img}:${tag}" "${img}:latest"
+            docker save -o "${OUT}/airwaves-${svc}.tar" \
+              "${img}:${tag}" "${img}:${CHANNEL}" "${img}:latest"
+          }
+          bundle "$MGR_IMG" "$MGR_TAG" "manager"
+          bundle "$GW_IMG"  "$GW_TAG"  "gateway"
+          docker image prune -af >/dev/null 2>&1 || true
+          ls -lh "$OUT"/*.tar
+
       - name: Install userpatches
         env:
           EXTRA_PARAMS: ${{ env.INPUT_EXTRA_PARAMS }}

--- a/.gitignore
+++ b/.gitignore
@@ -10,6 +10,10 @@ output/
 *.img
 *.img.xz
 
+# Pre-baked container tarballs staged into the image at build time
+# (docker-save'd by the CI bundle step; never committed)
+armbian/userpatches/extensions/airwaves-os/images/*.tar
+
 # Dev environment
 dev/config/
 

--- a/armbian/userpatches/common-airwaves.conf
+++ b/armbian/userpatches/common-airwaves.conf
@@ -1,11 +1,14 @@
 display_alert "Include" "common-airwaves" "info"
 
-# Extensions
+# Extensions (must be enabled here at include time, before extension init — too
+# late from a user_config hook). airwaves-live self-guards on uefi-x86, so it is
+# a no-op on other boards.
 enable_extension "airwaves-base"
 enable_extension "airwaves-docker"
 enable_extension "airwaves-networking"
 enable_extension "airwaves-hardware"
 enable_extension "airwaves-installer"
+enable_extension "airwaves-live"
 
 # Base OS settings
 declare -g BUILD_MINIMAL="yes"
@@ -64,16 +67,6 @@ function user_config__airwaves_grub_distro() {
 	if [[ "${BOARD}" == "uefi-x86" ]]; then
 		display_alert "Branding GRUB menu" "Airwaves OS v<version>" "info"
 		declare -g UEFI_GRUB_DISTRO_NAME='$(. /etc/airwaves-release 2>/dev/null; echo Airwaves OS v${AIRWAVES_VERSION:-})'
-	fi
-}
-
-# Enable the Live USB extension on x86 only (gated in a user_config hook so BOARD
-# is set). It makes the rootfs live-boot capable; the workflow builds the actual
-# Live USB image. Dormant on a normal/embedded boot.
-function user_config__airwaves_live_extension() {
-	if [[ "${BOARD}" == "uefi-x86" ]]; then
-		display_alert "Enabling Airwaves OS Live USB extension" "uefi-x86" "info"
-		enable_extension "airwaves-live"
 	fi
 }
 

--- a/armbian/userpatches/common-airwaves.conf
+++ b/armbian/userpatches/common-airwaves.conf
@@ -67,6 +67,16 @@ function user_config__airwaves_grub_distro() {
 	fi
 }
 
+# Enable the Live USB extension on x86 only (gated in a user_config hook so BOARD
+# is set). It makes the rootfs live-boot capable; the workflow builds the actual
+# Live USB image. Dormant on a normal/embedded boot.
+function user_config__airwaves_live_extension() {
+	if [[ "${BOARD}" == "uefi-x86" ]]; then
+		display_alert "Enabling Airwaves OS Live USB extension" "uefi-x86" "info"
+		enable_extension "airwaves-live"
+	fi
+}
+
 function run_after_build__export_image_version_to_gha() {
     github_actions_add_output "armbian_image_version" "${version}"
 }

--- a/armbian/userpatches/common-airwaves.conf
+++ b/armbian/userpatches/common-airwaves.conf
@@ -54,6 +54,19 @@ function user_config__airwaves_serial_console() {
 	fi
 }
 
+# Brand the x86 GRUB menu as "Airwaves OS v<version>" instead of Armbian. Armbian's
+# grub extension writes GRUB_DISTRIBUTOR="${UEFI_GRUB_DISTRO_NAME}" into
+# /etc/default/grub.d/98-armbian.cfg, leaving an inner $(...) literal — so a
+# command-substitution value is evaluated live by grub-mkconfig from
+# /etc/airwaves-release. The title auto-updates with the OS version (and per A/B
+# slot) with no re-baking.
+function user_config__airwaves_grub_distro() {
+	if [[ "${BOARD}" == "uefi-x86" ]]; then
+		display_alert "Branding GRUB menu" "Airwaves OS v<version>" "info"
+		declare -g UEFI_GRUB_DISTRO_NAME='$(. /etc/airwaves-release 2>/dev/null; echo Airwaves OS v${AIRWAVES_VERSION:-})'
+	fi
+}
+
 function run_after_build__export_image_version_to_gha() {
     github_actions_add_output "armbian_image_version" "${version}"
 }

--- a/armbian/userpatches/extensions/airwaves-base.sh
+++ b/armbian/userpatches/extensions/airwaves-base.sh
@@ -50,7 +50,15 @@ function post_family_tweaks__airwaves_base_setup() {
 
 	# Create airwaves user (docker group added later by airwaves-docker extension)
 	display_alert "Creating airwaves user" "${EXTENSION}" "info"
-	chroot_sdcard useradd -m -s /bin/bash -G sudo,plugdev airwaves
+	chroot_sdcard useradd -m -s /bin/bash -G sudo,plugdev airwaves || \
+		chroot_sdcard usermod -s /bin/bash airwaves
+	# Guarantee the home directory exists, is populated from skel, and is owned by
+	# airwaves — some build paths leave `useradd -m` without a home, which then
+	# breaks SSH login ("Could not chdir to home directory /home/airwaves").
+	chroot_sdcard mkdir -p /home/airwaves
+	chroot_sdcard cp -rTn /etc/skel /home/airwaves 2>/dev/null || true
+	chroot_sdcard chown -R airwaves:airwaves /home/airwaves
+	chroot_sdcard chmod 755 /home/airwaves
 	# Set password using chpasswd via heredoc (avoids pipe parsing issues in chroot)
 	echo "airwaves:airwaves" | chroot "${SDCARD}" /usr/sbin/chpasswd
 

--- a/armbian/userpatches/extensions/airwaves-base.sh
+++ b/armbian/userpatches/extensions/airwaves-base.sh
@@ -172,3 +172,27 @@ ISSUE
 	run_host_command_logged cp "${SDCARD}"/opt/airwaves/config/templates/systemd-airwaves-preconfig.service "${SDCARD}"/etc/systemd/system/airwaves-preconfig.service
 	chroot_sdcard systemctl --no-reload enable airwaves-preconfig.service
 }
+
+# Overlay the pre-built container tarballs onto the FINAL image at assembly time,
+# after the rootfs is laid into the mounted image (${MOUNT}) and before unmount.
+# pre_install_kernel_debs (above) already bakes them into the rootfs for a fresh
+# build, but the production split build (build-os-image.yml) can reuse a CACHED
+# rootfs artifact that predates a container bump — the generated tarballs aren't
+# part of Armbian's content hash. Re-copying them here guarantees the shipped
+# image always carries the current offline containers regardless of caching.
+# Fully guarded: a no-op when none are staged, and never fails the build.
+function pre_umount_final_image__airwaves_bake_container_images() {
+	local src_images="${SRC}/userpatches/extensions/airwaves-os/images"
+	if ! compgen -G "${src_images}/*.tar" >/dev/null 2>&1; then
+		return 0
+	fi
+	display_alert "Overlaying pre-built container images into image" \
+		"$(ls -1 "${src_images}"/*.tar | wc -l | tr -d ' ') tarball(s)" "info"
+	mkdir -p "${MOUNT}/opt/airwaves/images" 2>/dev/null || true
+	if cp -a "${src_images}"/*.tar "${MOUNT}/opt/airwaves/images/" 2>/dev/null; then
+		run_host_command_logged ls -lh "${MOUNT}/opt/airwaves/images/" || true
+	else
+		display_alert "Could not overlay container tarballs" "non-fatal; device will pull on first boot" "wrn"
+	fi
+	return 0
+}

--- a/armbian/userpatches/extensions/airwaves-base.sh
+++ b/armbian/userpatches/extensions/airwaves-base.sh
@@ -27,6 +27,22 @@ function pre_install_kernel_debs__copy_airwaves_files() {
 		run_host_command_logged cp -aR "${extension_data_dir}/scripts" "${SDCARD}"/opt/airwaves/
 		run_host_command_logged chmod -R +x "${SDCARD}"/opt/airwaves/scripts
 	fi
+
+	# Bake pre-built container images so first boot needs NO network. The CI
+	# image-build workflow docker-save's the manager+gateway images of the release
+	# pinned in releases/<channel>.json into ${extension_data_dir}/images/*.tar
+	# (matching this board's CPU arch). airwaves-init loads them on first boot
+	# before falling back to a registry pull. If none are staged (e.g. a local
+	# dev build), this is a no-op and the device pulls online on first boot.
+	if compgen -G "${extension_data_dir}/images/*.tar" >/dev/null 2>&1; then
+		display_alert "Baking pre-built container images" \
+			"$(ls -1 "${extension_data_dir}"/images/*.tar | wc -l | tr -d ' ') tarball(s)" "info"
+		run_host_command_logged cp -a "${extension_data_dir}"/images/*.tar "${SDCARD}"/opt/airwaves/images/
+		run_host_command_logged ls -lh "${SDCARD}/opt/airwaves/images/"
+	else
+		display_alert "No pre-built container images staged" \
+			"first boot will pull from registry (needs network)" "wrn"
+	fi
 }
 
 function post_family_tweaks__airwaves_base_setup() {
@@ -106,18 +122,9 @@ function post_family_tweaks__airwaves_base_setup() {
 
 ISSUE
 
-	# Brand the GRUB menu (x86): title entries "Airwaves OS v<version>" instead of
-	# Armbian/Debian. The value is a command substitution evaluated by
-	# grub-mkconfig from the LIVE /etc/airwaves-release, so it stays current after
-	# every OS update (and per A/B slot) with no re-baking.
-	if [[ "${ARCH}" == "amd64" ]] && [ -f "${SDCARD}/etc/default/grub" ]; then
-		display_alert "Branding GRUB menu" "Airwaves OS v<version>" "info"
-		local _gd='GRUB_DISTRIBUTOR="$(. /etc/airwaves-release 2>/dev/null; echo Airwaves OS v${AIRWAVES_VERSION:-})"'
-		grep -v '^GRUB_DISTRIBUTOR=' "${SDCARD}/etc/default/grub" > "${SDCARD}/etc/default/grub.aw" 2>/dev/null || true
-		echo "${_gd}" >> "${SDCARD}/etc/default/grub.aw"
-		mv "${SDCARD}/etc/default/grub.aw" "${SDCARD}/etc/default/grub"
-		chroot_sdcard update-grub 2>/dev/null || chroot_sdcard grub-mkconfig -o /boot/grub/grub.cfg 2>/dev/null || true
-	fi
+	# (GRUB menu is branded "Airwaves OS v<version>" via UEFI_GRUB_DISTRO_NAME in
+	# common-airwaves.conf — Armbian's grub extension runs after this and would
+	# overwrite /etc/default/grub anyway.)
 
 	# Install app catalog
 	display_alert "Installing app catalog" "${EXTENSION}" "info"

--- a/armbian/userpatches/extensions/airwaves-base.sh
+++ b/armbian/userpatches/extensions/airwaves-base.sh
@@ -155,4 +155,12 @@ ISSUE
 	display_alert "Installing airwaves-init service" "${EXTENSION}" "info"
 	run_host_command_logged cp "${SDCARD}"/opt/airwaves/config/templates/systemd-airwaves-init.service "${SDCARD}"/etc/systemd/system/airwaves-init.service
 	chroot_sdcard systemctl --no-reload enable airwaves-init.service
+
+	# Install pre-config service (applies the AWCFG config partition on first
+	# setup, or when an apply.conf trigger is present — runs before init). The
+	# airwaves-preconfig script itself is copied with the rest of /opt/airwaves/
+	# scripts above.
+	display_alert "Installing airwaves-preconfig service" "${EXTENSION}" "info"
+	run_host_command_logged cp "${SDCARD}"/opt/airwaves/config/templates/systemd-airwaves-preconfig.service "${SDCARD}"/etc/systemd/system/airwaves-preconfig.service
+	chroot_sdcard systemctl --no-reload enable airwaves-preconfig.service
 }

--- a/armbian/userpatches/extensions/airwaves-installer.sh
+++ b/armbian/userpatches/extensions/airwaves-installer.sh
@@ -44,10 +44,19 @@ function post_family_tweaks__airwaves_installer_setup() {
 			"${SDCARD}"/etc/systemd/system/getty@tty1.service.d/airwaves-tui.conf
 	fi
 
-	# Launch the TUI from the tty1 login session only (serial/SSH get a shell).
+	# Launch the TUI from the tty1 autologin session, and for the 'airwaves'
+	# operator over SSH (serial + root SSH still get a shell).
 	if [ -f "${SDCARD}"/opt/airwaves/config/profile.d-airwaves-tui.sh ]; then
 		run_host_command_logged cp "${SDCARD}"/opt/airwaves/config/profile.d-airwaves-tui.sh \
 			"${SDCARD}"/etc/profile.d/zz-airwaves-tui.sh
+	fi
+
+	# Passwordless sudo for just the TUI launcher so the airwaves SSH session
+	# drops into a fully-functional console without a second password prompt.
+	if [ -f "${SDCARD}"/opt/airwaves/config/templates/sudoers-airwaves-tui ]; then
+		run_host_command_logged cp "${SDCARD}"/opt/airwaves/config/templates/sudoers-airwaves-tui \
+			"${SDCARD}"/etc/sudoers.d/airwaves-tui
+		run_host_command_logged chmod 0440 "${SDCARD}"/etc/sudoers.d/airwaves-tui
 	fi
 
 	# Retire the old first-run oneshot service if it was ever installed (the TUI

--- a/armbian/userpatches/extensions/airwaves-live.sh
+++ b/armbian/userpatches/extensions/airwaves-live.sh
@@ -60,19 +60,26 @@ case " $(cat /proc/cmdline 2>/dev/null) " in
     *" notoram "*)           TORAM="";      export TORAM; exit 0 ;;
 esac
 
-# Find the live medium's recorded squashfs size (written at build time).
+# Find the live medium's recorded squashfs size (written at build time). This
+# hook runs early — the medium's partitions may not be enumerated yet — so poll
+# for a few seconds until the AIRWAVES_LIVE partition with /live/filesystem.size
+# shows up.
 SQ_BYTES=0
-for dev in /dev/sd*[0-9] /dev/nvme*n*p* /dev/mmcblk*p*; do
-    [ -b "$dev" ] || continue
-    mp="$(mktemp -d /run/aw-livescan.XXXXXX 2>/dev/null)" || continue
-    if mount -t ext4 -o ro "$dev" "$mp" 2>/dev/null; then
-        if [ -f "$mp/live/filesystem.size" ]; then
-            SQ_BYTES="$(cat "$mp/live/filesystem.size" 2>/dev/null || echo 0)"
-            umount "$mp" 2>/dev/null; rmdir "$mp" 2>/dev/null; break
+for _try in $(seq 1 20); do
+    for dev in /dev/sd*[0-9] /dev/nvme*n*p* /dev/mmcblk*p*; do
+        [ -b "$dev" ] || continue
+        mp="$(mktemp -d /run/aw-livescan.XXXXXX 2>/dev/null)" || continue
+        if mount -t ext4 -o ro "$dev" "$mp" 2>/dev/null; then
+            if [ -f "$mp/live/filesystem.size" ]; then
+                SQ_BYTES="$(cat "$mp/live/filesystem.size" 2>/dev/null || echo 0)"
+                umount "$mp" 2>/dev/null; rmdir "$mp" 2>/dev/null; break
+            fi
+            umount "$mp" 2>/dev/null
         fi
-        umount "$mp" 2>/dev/null
-    fi
-    rmdir "$mp" 2>/dev/null
+        rmdir "$mp" 2>/dev/null
+    done
+    [ "$SQ_BYTES" -gt 0 ] 2>/dev/null && break
+    sleep 1
 done
 
 MEM_KB="$(awk '/^MemAvailable:/{print $2; exit}' /proc/meminfo 2>/dev/null || echo 0)"

--- a/armbian/userpatches/extensions/airwaves-live.sh
+++ b/armbian/userpatches/extensions/airwaves-live.sh
@@ -1,0 +1,116 @@
+#!/bin/bash
+#
+# Airwaves OS - Live USB extension (x86 only)
+#
+# Makes the rootfs capable of booting as a live system (Debian live-boot) so the
+# CI can build a separate "Live USB" image whose whole OS loads into RAM (toram).
+# Everything here is DORMANT on a normal/embedded boot (root=UUID): live-boot's
+# initramfs scripts and the tmpfs-docker unit only activate when the kernel is
+# booted with `boot=live`. The actual live image (squashfs + GPT + GRUB) is
+# assembled by the workflow's "Build Live USB" step from this rootfs.
+#
+# On a live boot the root is an overlay (squashfs + RAM tmpfs), and Docker's
+# overlay2 driver can't run on top of overlayfs — so we mount a RAM tmpfs at
+# /var/lib/docker (live-only) and the stack loads its images into RAM.
+#
+
+function extension_prepare_config__airwaves_live() {
+	[[ "${BOARD}" == "uefi-x86" ]] || return 0
+	display_alert "Preparing Airwaves OS Live USB extension" "${EXTENSION}" "info"
+}
+
+# Host tools needed to assemble the live image on the runner.
+function add_host_dependencies__airwaves_live() {
+	[[ "${BOARD}" == "uefi-x86" ]] || return 0
+	declare -g EXTRA_BUILD_DEPS="${EXTRA_BUILD_DEPS:-} squashfs-tools grub-efi-amd64-bin grub-pc-bin dosfstools e2fsprogs"
+}
+
+# live-boot in the rootfs makes the initramfs understand boot=live + toram. It is
+# inert unless the kernel cmdline says boot=live, so the embedded image that
+# ships the same rootfs is unaffected. (No live-config: Airwaves owns first-boot.)
+function user_config__airwaves_live_packages() {
+	[[ "${BOARD}" == "uefi-x86" ]] || return 0
+	display_alert "Adding live-boot packages" "${EXTENSION}" "info"
+	add_packages_to_rootfs live-boot live-boot-initramfs-tools
+}
+
+function post_family_tweaks__airwaves_live_setup() {
+	[[ "${BOARD}" == "uefi-x86" ]] || return 0
+	display_alert "Installing Live USB (toram) support" "${EXTENSION}" "info"
+
+	# --- auto-RAM-gate initramfs hook ---------------------------------------
+	# Runs from the initramfs during a live boot, BEFORE live-boot's 9990-main
+	# (prefix 0050 < 9990). initramfs-tools SOURCES these scripts, so setting
+	# TORAM here is seen by live-boot's copy logic. We enable toram only when
+	# there's enough free RAM to hold the squashfs + overlay + the RAM docker
+	# store, with headroom; otherwise we leave it running from USB. An explicit
+	# `toram`/`notoram` on the cmdline always wins.
+	local premount="${SDCARD}/usr/share/initramfs-tools/scripts/live-premount"
+	run_host_command_logged mkdir -p "${premount}"
+	cat > "${premount}/0050-airwaves-autotoram" <<'HOOK'
+#!/bin/sh
+# Airwaves OS: decide toram automatically based on available RAM vs squashfs size.
+PREREQ=""
+prereqs() { echo "$PREREQ"; }
+case "$1" in prereqs) prereqs; exit 0 ;; esac
+
+# An explicit choice on the cmdline always wins.
+case " $(cat /proc/cmdline 2>/dev/null) " in
+    *" toram "*|*" toram="*) TORAM="true";  export TORAM; exit 0 ;;
+    *" notoram "*)           TORAM="";      export TORAM; exit 0 ;;
+esac
+
+# Find the live medium's recorded squashfs size (written at build time).
+SQ_BYTES=0
+for dev in /dev/sd*[0-9] /dev/nvme*n*p* /dev/mmcblk*p*; do
+    [ -b "$dev" ] || continue
+    mp="$(mktemp -d /run/aw-livescan.XXXXXX 2>/dev/null)" || continue
+    if mount -t ext4 -o ro "$dev" "$mp" 2>/dev/null; then
+        if [ -f "$mp/live/filesystem.size" ]; then
+            SQ_BYTES="$(cat "$mp/live/filesystem.size" 2>/dev/null || echo 0)"
+            umount "$mp" 2>/dev/null; rmdir "$mp" 2>/dev/null; break
+        fi
+        umount "$mp" 2>/dev/null
+    fi
+    rmdir "$mp" 2>/dev/null
+done
+
+MEM_KB="$(awk '/^MemAvailable:/{print $2; exit}' /proc/meminfo 2>/dev/null || echo 0)"
+MEM_BYTES=$(( MEM_KB * 1024 ))
+# Headroom for the overlay tmpfs + the RAM-backed /var/lib/docker the stack uses.
+OVERHEAD=$(( 1024 * 1024 * 1024 ))
+
+if [ "$SQ_BYTES" -gt 0 ] && [ "$MEM_BYTES" -gt $(( SQ_BYTES + OVERHEAD )) ]; then
+    TORAM="true"; export TORAM
+    echo "airwaves-autotoram: loading to RAM (MemAvailable=${MEM_KB}kB squashfs=${SQ_BYTES}B)"
+else
+    echo "airwaves-autotoram: running from USB (MemAvailable=${MEM_KB}kB squashfs=${SQ_BYTES}B)"
+fi
+exit 0
+HOOK
+	run_host_command_logged chmod +x "${premount}/0050-airwaves-autotoram"
+
+	# --- live-only tmpfs for /var/lib/docker --------------------------------
+	# On a live (overlay) root, Docker's overlay2 store can't live on overlayfs.
+	# Mount a RAM tmpfs at /var/lib/docker so the stack runs in RAM. The condition
+	# makes this a no-op on a normal/embedded boot (real disk for docker).
+	cat > "${SDCARD}/etc/systemd/system/airwaves-live-docker-tmpfs.service" <<'UNIT'
+[Unit]
+Description=Airwaves OS live: RAM tmpfs for /var/lib/docker
+Documentation=https://airwavesos.com
+ConditionKernelCommandLine=boot=live
+DefaultDependencies=no
+After=local-fs.target
+Before=docker.service airwaves-init.service airwaves-containers.service
+RequiresMountsFor=/var/lib
+
+[Service]
+Type=oneshot
+RemainAfterExit=yes
+ExecStart=/bin/mount -t tmpfs -o size=75%,mode=0710 tmpfs /var/lib/docker
+
+[Install]
+WantedBy=multi-user.target
+UNIT
+	chroot_sdcard systemctl --no-reload enable airwaves-live-docker-tmpfs.service
+}

--- a/armbian/userpatches/extensions/airwaves-networking.sh
+++ b/armbian/userpatches/extensions/airwaves-networking.sh
@@ -1,7 +1,14 @@
 #!/bin/bash
 #
 # Airwaves OS - Networking Extension
-# Handles: systemd-networkd, avahi/mDNS, WiFi support
+# Handles: NetworkManager (wifi + ethernet), avahi/mDNS
+#
+# We use NetworkManager as the single network backend so the manager API and the
+# console rescue TUI can both drive Wi-Fi through one tool (nmcli). systemd-networkd
+# is masked to avoid a split-brain with NM. The *-wait-online units are masked too:
+# blocking boot until the network is up adds a ~1-2 min delay when a device has no
+# carrier/DHCP (the "first boot takes forever before the console" symptom), and the
+# appliance must come up fast even with no network.
 #
 
 function extension_prepare_config__airwaves_networking() {
@@ -10,25 +17,47 @@ function extension_prepare_config__airwaves_networking() {
 
 function user_config__airwaves_networking_packages() {
 	display_alert "Adding networking packages" "${EXTENSION}" "info"
-	add_packages_to_rootfs avahi-daemon avahi-utils libnss-mdns
+	# network-manager pulls wpasupplicant (wifi auth). iw is handy for diagnostics.
+	add_packages_to_rootfs network-manager iw avahi-daemon avahi-utils libnss-mdns
 }
 
 function post_family_tweaks__airwaves_networking_setup() {
 	display_alert "Configuring Airwaves OS networking" "${EXTENSION}" "info"
 
-	# Configure avahi for mDNS discovery
-	# The hostname will be set dynamically by airwaves-init (airwaves-XXXXXX)
-	# Avahi will automatically advertise <hostname>.local
+	# --- NetworkManager as the single backend -------------------------------
+	display_alert "Enabling NetworkManager" "${EXTENSION}" "info"
+	chroot_sdcard systemctl --no-reload enable NetworkManager.service
 
-	# Install avahi service definitions for web UI discovery
+	# Mask systemd-networkd so it can't fight NM over the interfaces. Mask the
+	# wait-online units (both stacks) so boot never blocks on the network.
+	chroot_sdcard systemctl --no-reload mask \
+		systemd-networkd.service \
+		systemd-networkd.socket \
+		systemd-networkd-wait-online.service \
+		NetworkManager-wait-online.service || true
+
+	# Drop any Armbian-provided networkd interface configs so a future unmask
+	# can't reapply them behind NM's back.
+	run_host_command_logged rm -f "${SDCARD}"/etc/systemd/network/*.network 2>/dev/null || true
+
+	# Keep NM's hands off docker's interfaces (docker0, veth*, br-* compose
+	# bridges) so container networking is never disrupted by NM.
+	run_host_command_logged mkdir -p "${SDCARD}/etc/NetworkManager/conf.d"
+	cat > "${SDCARD}/etc/NetworkManager/conf.d/10-airwaves-unmanaged.conf" << 'EOF'
+# Airwaves OS: let Docker own its own interfaces; NM manages only real NICs.
+[keyfile]
+unmanaged-devices=interface-name:docker*;interface-name:veth*;interface-name:br-*;interface-name:vmnet*
+EOF
+
+	# --- avahi / mDNS --------------------------------------------------------
+	# The hostname is set dynamically by airwaves-init (airwaves-XXXXXX); avahi
+	# advertises <hostname>.local so the web UI is discoverable.
+	display_alert "Configuring avahi (mDNS)" "${EXTENSION}" "info"
 	run_host_command_logged cp "${SDCARD}"/opt/airwaves/config/templates/avahi-airwaves-web.service \
 		"${SDCARD}"/etc/avahi/services/airwaves-web.service
-
-	# Enable avahi-daemon
 	chroot_sdcard systemctl --no-reload enable avahi-daemon.service
 
-	# Configure systemd-resolved to not conflict with avahi
-	# (on minimal builds, systemd-networkd is the default)
+	# Let avahi own .local; tell systemd-resolved (if present) to stay out of it.
 	if [ -d "${SDCARD}/etc/systemd/resolved.conf.d" ] || mkdir -p "${SDCARD}/etc/systemd/resolved.conf.d"; then
 		cat > "${SDCARD}/etc/systemd/resolved.conf.d/airwaves.conf" << 'EOF'
 [Resolve]
@@ -37,5 +66,5 @@ MulticastDNS=no
 EOF
 	fi
 
-	display_alert "Networking configured (systemd-networkd + avahi)" "${EXTENSION}" "info"
+	display_alert "Networking configured (NetworkManager + avahi)" "${EXTENSION}" "info"
 }

--- a/armbian/userpatches/extensions/airwaves-os/config/awcfg/README.txt
+++ b/armbian/userpatches/extensions/airwaves-os/config/awcfg/README.txt
@@ -1,0 +1,60 @@
+========================================================================
+ Airwaves OS - configuration partition (AWCFG)
+========================================================================
+
+This small FAT32 partition lets you pre-configure or recover an Airwaves OS
+device WITHOUT a screen or keyboard. You can edit it on any computer
+(Windows, macOS, Linux) before or after flashing the card.
+
+Edit the file:  airwaves-install.json
+
+------------------------------------------------------------------------
+WHEN IS IT USED?
+------------------------------------------------------------------------
+1) FIRST setup. On the very first boot of a freshly flashed device, Airwaves
+   OS reads airwaves-install.json automatically and applies it.
+
+2) LATER, on a device that is already set up. The file is IGNORED on normal
+   boots. To make Airwaves OS apply it again, also create an empty file named:
+
+        apply.conf
+
+   On the next boot the device reads airwaves-install.json, applies it, and
+   deletes apply.conf (so it only applies once).
+
+   This is the easy way to fix Wi-Fi on a headless device: power it off, pull
+   the card, edit the "wifi" section below, create apply.conf, put the card
+   back, and power on. It reconnects with the new Wi-Fi.
+
+------------------------------------------------------------------------
+FIELDS (all optional; leave blank to skip)
+------------------------------------------------------------------------
+  hostname   Device name on the network (letters, digits, hyphens).
+  wifi.ssid  Wi-Fi network name.
+  wifi.psk   Wi-Fi password (leave blank for an open network).
+  channel    Update channel: stable | beta | dev.
+  timezone   e.g. "America/Chicago".
+  ssh_keys   List of SSH public keys to authorize for remote login.
+
+  The following control UNATTENDED INSTALL to an internal disk and are OFF
+  by default. They ERASE the target disk, so BOTH of the first two must be
+  set to true before anything is erased.
+
+  NOTE (current release): unattended install via these fields is NOT active
+  yet and setting them has no effect. Use the on-screen installer for now.
+  They are documented here because they will be enabled in a coming update:
+
+  auto_install        true to install automatically (no menu).
+  confirm_destructive true to acknowledge the target disk will be ERASED.
+  target              "auto", "largest", or a device like "/dev/nvme0n1".
+  ab                  true for A/B (blue/green) layout (needs >= 12 GiB).
+  self_install        true to let a card flashed to SD self-install to the
+                      device's internal eMMC/NVMe (ARM boards).
+  post_install        "poweroff" or "reboot" after a successful install.
+
+------------------------------------------------------------------------
+SECURITY NOTE
+------------------------------------------------------------------------
+This partition is NOT encrypted. The Wi-Fi password is stored in plain text
+and can be read by anyone who has the card. Keep the card physically secure,
+or clear the "psk" field after the device has connected.

--- a/armbian/userpatches/extensions/airwaves-os/config/awcfg/airwaves-install.json
+++ b/armbian/userpatches/extensions/airwaves-os/config/awcfg/airwaves-install.json
@@ -1,0 +1,18 @@
+{
+  "schema": 1,
+  "hostname": "",
+  "wifi": {
+    "ssid": "",
+    "psk": ""
+  },
+  "channel": "",
+  "timezone": "",
+  "ssh_keys": [],
+
+  "auto_install": false,
+  "confirm_destructive": false,
+  "target": "auto",
+  "ab": false,
+  "self_install": false,
+  "post_install": "poweroff"
+}

--- a/armbian/userpatches/extensions/airwaves-os/config/dialogrc
+++ b/armbian/userpatches/extensions/airwaves-os/config/dialogrc
@@ -1,0 +1,30 @@
+# Airwaves OS — shared dialog(1) theme (black background, cyan/yellow accents).
+# Used by airwaves-tui AND airwaves-firstrun (the installer flow) so every screen
+# looks the same. Point DIALOGRC at this file.
+use_shadow = OFF
+use_colors = ON
+screen_color = (CYAN,BLACK,ON)
+dialog_color = (CYAN,BLACK,ON)
+title_color = (YELLOW,BLACK,ON)
+border_color = (CYAN,BLACK,ON)
+border2_color = (CYAN,BLACK,ON)
+menubox_color = (WHITE,BLACK,OFF)
+menubox_border_color = (CYAN,BLACK,ON)
+menubox_border2_color = (CYAN,BLACK,ON)
+item_color = (WHITE,BLACK,OFF)
+item_selected_color = (BLACK,CYAN,ON)
+tag_color = (YELLOW,BLACK,ON)
+tag_selected_color = (BLACK,CYAN,ON)
+tag_key_color = (YELLOW,BLACK,OFF)
+tag_key_selected_color = (BLACK,CYAN,ON)
+button_active_color = (BLACK,CYAN,ON)
+button_inactive_color = (CYAN,BLACK,OFF)
+button_key_active_color = (BLACK,CYAN,ON)
+button_key_inactive_color = (YELLOW,BLACK,OFF)
+button_label_active_color = (BLACK,CYAN,ON)
+button_label_inactive_color = (CYAN,BLACK,ON)
+inputbox_color = (WHITE,BLACK,OFF)
+inputbox_border_color = (CYAN,BLACK,ON)
+searchbox_color = (WHITE,BLACK,OFF)
+position_indicator_color = (YELLOW,BLACK,ON)
+gauge_color = (CYAN,BLACK,ON)

--- a/armbian/userpatches/extensions/airwaves-os/config/profile.d-airwaves-tui.sh
+++ b/armbian/userpatches/extensions/airwaves-os/config/profile.d-airwaves-tui.sh
@@ -1,8 +1,20 @@
-# Airwaves OS: launch the console TUI on the main VT (tty1) only. The serial
-# console and SSH fall through to a normal shell. The TUI's "Open a shell"
-# action sets AIRWAVES_TUI_SHELL=1 so the nested shell does not relaunch the TUI.
+# Airwaves OS: launch the console TUI for the appliance operator.
+#   - tty1: the autologin (root) console.
+#   - SSH as the 'airwaves' user: drop straight into the console instead of a
+#     shell. Run it via sudo so privileged actions (reboot, install, etc.) work;
+#     fall back to an unprivileged console if passwordless sudo isn't available.
+# The serial console and root SSH fall through to a normal shell. The TUI's
+# "Open a shell" action sets AIRWAVES_TUI_SHELL=1 so the nested shell does not
+# relaunch the TUI.
 if [ -z "${AIRWAVES_TUI_SHELL:-}" ] && [ -x /opt/airwaves/scripts/airwaves-tui ]; then
     case "$(tty 2>/dev/null)" in
         /dev/tty1) exec /opt/airwaves/scripts/airwaves-tui ;;
     esac
+    if [ -n "${SSH_CONNECTION:-}" ] && [ "$(id -un 2>/dev/null)" = "airwaves" ]; then
+        if sudo -n -l /opt/airwaves/scripts/airwaves-tui >/dev/null 2>&1; then
+            exec sudo /opt/airwaves/scripts/airwaves-tui
+        else
+            exec /opt/airwaves/scripts/airwaves-tui
+        fi
+    fi
 fi

--- a/armbian/userpatches/extensions/airwaves-os/config/templates/sudoers-airwaves-tui
+++ b/armbian/userpatches/extensions/airwaves-os/config/templates/sudoers-airwaves-tui
@@ -1,0 +1,5 @@
+# Airwaves OS: let the appliance operator open the console over SSH with full
+# privileges without a second password prompt. 'airwaves' is already a sudoer
+# (sudo group), so this grants no new power — it just removes the prompt for the
+# one launcher path used by /etc/profile.d/zz-airwaves-tui.sh.
+airwaves ALL=(root) NOPASSWD: /opt/airwaves/scripts/airwaves-tui

--- a/armbian/userpatches/extensions/airwaves-os/config/templates/systemd-airwaves-init.service
+++ b/armbian/userpatches/extensions/airwaves-os/config/templates/systemd-airwaves-init.service
@@ -1,8 +1,13 @@
 [Unit]
 Description=Airwaves OS Initialization
 Documentation=https://airwavesos.com
-After=local-fs.target
-Before=docker.service airwaves-containers.service
+# airwaves-init runs docker load / network create / compose up, so the daemon
+# must already be up. Order AFTER docker and BEFORE the steady-state container
+# service (which does the same compose up on later boots). No network-online dep:
+# first boot must work offline by loading the pre-baked image tarballs.
+After=local-fs.target docker.service
+Requires=docker.service
+Before=airwaves-containers.service
 ConditionPathExists=/opt/airwaves/.needs-first-run
 
 [Service]

--- a/armbian/userpatches/extensions/airwaves-os/config/templates/systemd-airwaves-preconfig.service
+++ b/armbian/userpatches/extensions/airwaves-os/config/templates/systemd-airwaves-preconfig.service
@@ -1,0 +1,20 @@
+[Unit]
+Description=Airwaves OS pre-configuration (AWCFG partition)
+Documentation=https://airwavesos.com
+# Apply declarative config (hostname/Wi-Fi/channel) before first-boot init runs,
+# so the hostname is set before airwaves-init would derive one from the MAC and
+# Wi-Fi is up before the stack starts. nmcli needs NetworkManager, so order after
+# it. The script itself decides whether to act (first setup, or apply.conf), so
+# no ConditionPathExists here — it fast-exits when AWCFG is inert.
+After=local-fs.target NetworkManager.service
+Before=airwaves-init.service airwaves-containers.service
+
+[Service]
+Type=oneshot
+RemainAfterExit=yes
+ExecStart=/opt/airwaves/scripts/airwaves-preconfig
+TimeoutStartSec=120
+StandardOutput=journal+console
+
+[Install]
+WantedBy=multi-user.target

--- a/armbian/userpatches/extensions/airwaves-os/scripts/airwaves-firstrun
+++ b/armbian/userpatches/extensions/airwaves-os/scripts/airwaves-firstrun
@@ -33,7 +33,15 @@ fi
 [ -t 0 ] || { [ "${MODE}" = "install" ] && echo "airwaves-install: no interactive terminal." >&2; exit 0; }
 command -v dialog >/dev/null || { [ "${MODE}" = "install" ] && echo "airwaves-install: 'dialog' is not installed." >&2; exit 0; }
 
-export DIALOGRC=/dev/null
+# Match the console TUI's branded theme (black/cyan) so the installer flow looks
+# the same whether launched from the TUI or run standalone.
+if [ -r /opt/airwaves/config/dialogrc ]; then
+    export DIALOGRC=/opt/airwaves/config/dialogrc
+elif [ -r /run/airwaves-tui.dialogrc ]; then
+    export DIALOGRC=/run/airwaves-tui.dialogrc
+else
+    export DIALOGRC=/dev/null
+fi
 BT="Airwaves OS Installer"
 
 banner() {

--- a/armbian/userpatches/extensions/airwaves-os/scripts/airwaves-firstrun
+++ b/armbian/userpatches/extensions/airwaves-os/scripts/airwaves-firstrun
@@ -67,14 +67,44 @@ pick_disk() {
         3>&1 1>&2 2>&3
 }
 
+PRECONF="/run/airwaves/install-config.json"
+
+# Collect hostname (+ optional Wi-Fi) for the installed system BEFORE writing the
+# disk. Saved to PRECONF and passed to the installer via --config, which seeds it
+# onto the target's AWCFG partition; the target applies it on first boot. Skipping
+# any prompt just leaves that field empty (Ethernet/DHCP needs nothing).
+ask_preinstall_config() {
+    mkdir -p /run/airwaves 2>/dev/null || true
+    local cur host ssid="" psk=""
+    cur="$(hostname 2>/dev/null)"; [ -n "${cur}" ] || cur="airwaves"
+    host="$(dialog --backtitle "${BT}" --title "Hostname" \
+        --inputbox "\nHostname for the installed system (letters, digits, hyphens):" 10 62 "${cur}" 3>&1 1>&2 2>&3)" || host="${cur}"
+    [ -n "${host}" ] || host="${cur}"
+    if dialog --backtitle "${BT}" --title "Wi-Fi" --defaultno \
+        --yesno "\nConfigure Wi-Fi for the installed system?\n\n(Choose No if it will use wired Ethernet.)" 9 58; then
+        ssid="$(dialog --backtitle "${BT}" --title "Wi-Fi SSID" --inputbox "\nWi-Fi network name (SSID):" 10 60 3>&1 1>&2 2>&3)" || ssid=""
+        if [ -n "${ssid}" ]; then
+            psk="$(dialog --backtitle "${BT}" --title "Wi-Fi password" --insecure \
+                --passwordbox "\nPassword for ${ssid} (blank for an open network):" 10 60 3>&1 1>&2 2>&3)" || psk=""
+        fi
+    fi
+    jq -n --arg h "${host}" --arg s "${ssid}" --arg p "${psk}" \
+        '{hostname:$h, wifi:{ssid:$s, psk:$p}, channel:"", timezone:"", ssh_keys:[]}' \
+        > "${PRECONF}" 2>/dev/null || true
+    chmod 600 "${PRECONF}" 2>/dev/null || true
+}
+
 run_install() {
     local target="$1"
     dialog --backtitle "${BT}" --title "Confirm install" --defaultno \
         --yesno "\nThis will ERASE ALL DATA on:\n\n    ${target}\n\nand install Airwaves OS onto it.\n\nContinue?" 12 60 || return 1
 
+    # Ask for hostname / Wi-Fi to provision the installed system.
+    ask_preinstall_config
+
     rm -f "${STATUS}"
     # Run the installer in the background; render its status.json as a gauge.
-    AIRWAVES_INSTALL_APPLY=1 "${INSTALL}" --target "${target}" >/var/log/airwaves-install.log 2>&1 &
+    AIRWAVES_INSTALL_APPLY=1 "${INSTALL}" --target "${target}" ${PRECONF:+--config "${PRECONF}"} >/var/log/airwaves-install.log 2>&1 &
     local pid=$!
 
     (

--- a/armbian/userpatches/extensions/airwaves-os/scripts/airwaves-firstrun
+++ b/armbian/userpatches/extensions/airwaves-os/scripts/airwaves-firstrun
@@ -12,6 +12,7 @@ set -uo pipefail
 
 INSTALL="/opt/airwaves/scripts/airwaves-install"
 STATUS="/etc/airwaves/install/status.json"
+SCAN="/tmp/airwaves-scan.json"   # cached output of `airwaves-install --scan-json`
 
 # Modes: default "boot" = the live/install menu shown on tty1 at first boot
 # (only on removable media). "--install" = launched on demand (by the
@@ -60,18 +61,27 @@ main_menu() {
 }
 
 pick_disk() {
-    local json rows=() dev size model
-    json="$("${INSTALL}" --list-json 2>/dev/null)"
-    local n; n="$(echo "${json}" | jq 'length' 2>/dev/null || echo 0)"
+    local json rows=() dev size model summary
+    # Scan (mounts each candidate read-only) so we can show what's on each drive
+    # and flag any that already run Airwaves OS. Cache it so run_install can warn.
+    dialog --backtitle "${BT}" --infobox \
+        "\nScanning drives — reading partitions and checking for existing\ninstalls (each drive is briefly mounted read-only)..." 7 66
+    json="$("${INSTALL}" --scan-json 2>/dev/null)"
+    printf '%s' "${json}" > "${SCAN}" 2>/dev/null || true
+    local n; n="$(printf '%s' "${json}" | jq 'length' 2>/dev/null || echo 0)"
     if [ "${n}" -eq 0 ] 2>/dev/null; then
         dialog --backtitle "${BT}" --msgbox "\nNo internal disks were found to install onto.\n\nAttach an internal drive (NVMe/SATA) and try again, or choose Run live." 10 60
         return 1
     fi
-    while read -r dev size model; do
-        rows+=("${dev}" "${size} ${model}")
-    done < <(echo "${json}" | jq -r '.[] | "\(.device) \(.size) \(.model // "disk")"')
+    # tag = device; item = "size  model  •  <contents summary>" (e.g. Airwaves OS v1.0.37).
+    # Join with the ASCII Unit Separator (0x1F), not a tab: `read` treats tabs as
+    # whitespace and collapses an empty model field, shifting the columns.
+    while IFS=$'\037' read -r dev size model summary; do
+        [ -n "${dev}" ] || continue
+        rows+=("${dev}" "${size}  ${model}  •  ${summary}")
+    done < <(printf '%s' "${json}" | jq -r '.[] | [.device, .size, ((.model // "") | if .=="" then "disk" else . end), (.summary // "")] | join("\u001f")')
     dialog --backtitle "${BT}" --title "Select target disk" \
-        --menu "\nWARNING: the selected disk will be ERASED.\n" 16 70 6 "${rows[@]}" \
+        --menu "\nWARNING: the selected disk will be ERASED.\nDrives already running Airwaves OS are marked below.\n" 18 78 8 "${rows[@]}" \
         3>&1 1>&2 2>&3
 }
 
@@ -104,6 +114,15 @@ ask_preinstall_config() {
 
 run_install() {
     local target="$1"
+    # Extra warning if the chosen drive already holds an Airwaves OS install
+    # (detected during the scan in pick_disk).
+    local aw_present aw_ver
+    aw_present="$(jq -r --arg d "${target}" '.[]|select(.device==$d)|(.airwaves.present // false)' "${SCAN}" 2>/dev/null)"
+    aw_ver="$(jq -r --arg d "${target}" '.[]|select(.device==$d)|(.airwaves.version // "")' "${SCAN}" 2>/dev/null)"
+    if [ "${aw_present}" = "true" ]; then
+        dialog --backtitle "${BT}" --title "Airwaves OS already installed here" --defaultno \
+            --yesno "\n${target} already has Airwaves OS${aw_ver:+ v${aw_ver}} installed.\n\nContinuing will ERASE that installation and ALL data on the\ndrive. Are you sure you want to overwrite it?" 13 66 || return 1
+    fi
     dialog --backtitle "${BT}" --title "Confirm install" --defaultno \
         --yesno "\nThis will ERASE ALL DATA on:\n\n    ${target}\n\nand install Airwaves OS onto it.\n\nContinue?" 12 60 || return 1
 

--- a/armbian/userpatches/extensions/airwaves-os/scripts/airwaves-firstrun
+++ b/armbian/userpatches/extensions/airwaves-os/scripts/airwaves-firstrun
@@ -21,13 +21,21 @@ SCAN="/tmp/airwaves-scan.json"   # cached output of `airwaves-install --scan-jso
 MODE="boot"
 [ "${1:-}" = "--install" ] && MODE="install"
 
+# Live = booted from the USB installer (incl. live-boot/toram, where root is an
+# overlay/tmpfs in RAM), NOT an installed internal disk.
+is_live_boot() {
+    grep -qw 'boot=live' /proc/cmdline 2>/dev/null && return 0
+    [ -d /run/live/medium ] && return 0
+    case "$(findmnt -no FSTYPE / 2>/dev/null)" in overlay|tmpfs|aufs) return 0 ;; esac
+    local rd
+    rd="$(lsblk -ndo pkname "$(findmnt -no SOURCE / 2>/dev/null)" 2>/dev/null)"
+    [ -n "$rd" ] && [ "$(cat "/sys/block/${rd}/removable" 2>/dev/null || echo 0)" = "1" ]
+}
+
 if [ "${MODE}" = "boot" ]; then
-    # If the root disk is not removable (i.e. we booted from an installed
-    # internal disk), do nothing and let getty take over.
-    root_src="$(findmnt -no SOURCE / 2>/dev/null)"
-    root_disk="$(lsblk -ndo pkname "${root_src}" 2>/dev/null)"
-    removable="$(cat "/sys/block/${root_disk}/removable" 2>/dev/null || echo 0)"
-    [ "${removable}" = "1" ] || exit 0
+    # Only run the live/install menu on the installer medium; on an installed
+    # internal disk, do nothing and let getty take over.
+    is_live_boot || exit 0
 fi
 
 # Need a real TTY and dialog; otherwise bail out quietly (never block boot).

--- a/armbian/userpatches/extensions/airwaves-os/scripts/airwaves-firstrun
+++ b/armbian/userpatches/extensions/airwaves-os/scripts/airwaves-firstrun
@@ -93,18 +93,22 @@ run_install() {
     wait "${pid}"; local rc=$?
     state="$(jq -r '.state // "unknown"' "${STATUS}" 2>/dev/null || echo unknown)"
     if [ "${rc}" -eq 0 ] && [ "${state}" = "success" ]; then
-        # Quiesce the live system (stop the stack, flush) so the reboot is clean,
-        # then have the user remove the USB BEFORE rebooting — otherwise the BIOS
-        # may boot the live USB again instead of the freshly installed disk.
+        # POWER OFF (not reboot): pulling the live USB while the system is still
+        # running from it spews I/O errors (the live root vanishes mid-shutdown).
+        # Powering off first lets the user remove the USB while the machine is
+        # OFF, then power on to boot the installed disk — clean, no errors.
+        # Stop the stack + flush + remount the live root read-only first so the
+        # final poweroff has nothing dirty to write.
+        dialog --backtitle "${BT}" --title "Installation complete" --no-collapse \
+            --msgbox "\nAirwaves OS was installed to:\n\n    ${target}\n\nThe device will now POWER OFF. When it does:\n  1. Remove the USB drive\n  2. Power the device back on\n\nIt will boot Airwaves OS from ${target}." 15 66
         clear
-        echo "Finishing up — stopping services and flushing disks..."
+        echo "Shutting down cleanly — please wait..."
         systemctl stop airwaves-containers.service 2>/dev/null || true
         docker compose -f /etc/airwaves/docker-compose.yml down --timeout 10 2>/dev/null || true
-        umount -l "${target}"* 2>/dev/null || true
+        umount -R "${target}"* 2>/dev/null || true
         sync; sync
-        dialog --backtitle "${BT}" --title "Installation complete" --no-collapse \
-            --msgbox "\nAirwaves OS was installed to:\n\n    ${target}\n\nRemove the USB drive NOW, then press ENTER to reboot.\nThe system will start up from ${target}." 13 64
-        clear; echo "Rebooting into the installed system..."; sync; systemctl reboot
+        mount -o remount,ro / 2>/dev/null || true
+        systemctl poweroff
         return 0
     else
         local err; err="$(jq -r '.error // "see /var/log/airwaves-install.log"' "${STATUS}" 2>/dev/null)"

--- a/armbian/userpatches/extensions/airwaves-os/scripts/airwaves-init
+++ b/armbian/userpatches/extensions/airwaves-os/scripts/airwaves-init
@@ -43,6 +43,18 @@ pin_compose_to_alias() {
     log "Pinned compose airwaves images -> :${alias}"
 }
 
+ensure_user_home() {
+    # Self-heal the airwaves home dir if a build/copy ever left it missing (SSH
+    # login fails with "Could not chdir to home directory" otherwise).
+    if id airwaves >/dev/null 2>&1 && [ ! -d /home/airwaves ]; then
+        log "Creating missing /home/airwaves"
+        mkdir -p /home/airwaves
+        cp -rTn /etc/skel /home/airwaves 2>/dev/null || true
+        chown -R airwaves:airwaves /home/airwaves
+        chmod 755 /home/airwaves
+    fi
+}
+
 generate_device_id() {
     log "Generating device ID..."
     local uuid
@@ -191,6 +203,7 @@ finalize() {
 # Main
 log "Starting Airwaves OS first-boot initialization..."
 
+ensure_user_home
 generate_device_id
 set_hostname
 setup_docker_networks

--- a/armbian/userpatches/extensions/airwaves-os/scripts/airwaves-init
+++ b/armbian/userpatches/extensions/airwaves-os/scripts/airwaves-init
@@ -95,7 +95,16 @@ set_hostname() {
 load_prebaked_containers() {
     log "Loading container images..."
 
-    # Try loading from pre-baked tarballs first
+    local alias
+    alias="$(channel_alias)"
+
+    # Try loading from pre-baked tarballs first. These are docker-save'd at image
+    # BUILD time (see build-image-simple.yml) from the manager+gateway images of
+    # the release pinned in releases/<channel>.json, so first boot needs NO
+    # network: the system can come up (and serve the manager/web UI for Wi-Fi
+    # setup) even with no connectivity. Each tarball carries the version tag, the
+    # channel alias (e.g. :stable), and :latest, so whatever the compose file
+    # references resolves locally.
     if [ -d "$AIRWAVES_IMAGES_DIR" ] && [ -n "$(ls -A "$AIRWAVES_IMAGES_DIR"/*.tar 2>/dev/null)" ]; then
         for image_tar in "$AIRWAVES_IMAGES_DIR"/*.tar; do
             local image_name
@@ -108,15 +117,16 @@ load_prebaked_containers() {
                 log "WARNING: Failed to load ${image_name}"
             fi
         done
-        log "Pre-baked container loading complete"
+        # Point compose at the channel alias the tarballs carry so `docker compose
+        # up` uses the loaded images instead of trying to pull :latest online.
+        pin_compose_to_alias "${alias}"
+        log "Pre-baked container loading complete (offline)"
         return 0
     fi
 
     # No tarballs - pull from GHCR registry for this device's release channel.
     log "No pre-baked images found, pulling from registry..."
     local registry="ghcr.io/airframesio"
-    local alias
-    alias="$(channel_alias)"
     log "Release channel image tag: :${alias}"
 
     for image in airwaves-gateway airwaves-manager; do

--- a/armbian/userpatches/extensions/airwaves-os/scripts/airwaves-init
+++ b/armbian/userpatches/extensions/airwaves-os/scripts/airwaves-init
@@ -53,6 +53,19 @@ generate_device_id() {
 }
 
 set_hostname() {
+    # Respect a hostname already chosen by airwaves-preconfig (AWCFG config
+    # partition), which runs before us. If config.device.hostname is set, use it
+    # instead of deriving one from the MAC.
+    local preset=""
+    [ -f "$AIRWAVES_CONFIG" ] && preset="$(jq -r '.device.hostname // empty' "$AIRWAVES_CONFIG" 2>/dev/null)"
+    if [ -n "$preset" ]; then
+        log "Using preconfigured hostname: ${preset}"
+        hostnamectl set-hostname "${preset}" 2>/dev/null || true
+        echo "${preset}" > /etc/hostname
+        systemctl restart avahi-daemon 2>/dev/null || true
+        return 0
+    fi
+
     log "Setting hostname from MAC address..."
 
     # Find the primary network interface MAC

--- a/armbian/userpatches/extensions/airwaves-os/scripts/airwaves-init
+++ b/armbian/userpatches/extensions/airwaves-os/scripts/airwaves-init
@@ -117,11 +117,31 @@ set_hostname() {
     systemctl restart avahi-daemon 2>/dev/null || true
 }
 
+images_present() {
+    # True only if BOTH airwaves images are already in the local docker store
+    # for the given tag (e.g. pre-extracted into /var/lib/docker at image build).
+    local alias="$1" img
+    for img in airwaves-gateway airwaves-manager; do
+        docker image inspect "ghcr.io/airframesio/${img}:${alias}" >/dev/null 2>&1 || return 1
+    done
+    return 0
+}
+
 load_prebaked_containers() {
     log "Loading container images..."
 
     local alias
     alias="$(channel_alias)"
+
+    # Fast path: the images were pre-extracted into the docker store at build time
+    # (lean live-USB image). Nothing to load — just align the compose tags and go.
+    if images_present "$alias"; then
+        log "Container images already present (pre-extracted at build); skipping load"
+        pin_compose_to_alias "$alias"
+        # Drop any leftover tarballs (none expected in the lean image) to reclaim space.
+        rm -f "$AIRWAVES_IMAGES_DIR"/*.tar 2>/dev/null || true
+        return 0
+    fi
 
     # Try loading from pre-baked tarballs first. These are docker-save'd at image
     # BUILD time (see build-image-simple.yml) from the manager+gateway images of

--- a/armbian/userpatches/extensions/airwaves-os/scripts/airwaves-install
+++ b/armbian/userpatches/extensions/airwaves-os/scripts/airwaves-install
@@ -135,6 +135,26 @@ detect_platform() {
 # ---- source / target discovery (mirrors armbian-install) -------------------
 
 discover_source() {
+    # Live-boot (USB installer, incl. toram): root is an overlay/tmpfs in RAM, so
+    # the source to exclude is the live MEDIUM, not "/". Resolve it from
+    # /run/live/medium, else the AIRWAVES_LIVE label, else the live-media= cmdline.
+    if grep -qw 'boot=live' /proc/cmdline 2>/dev/null || [ -d /run/live/medium ]; then
+        local live_dev lm
+        live_dev="$(findmnt -no SOURCE /run/live/medium 2>/dev/null)"
+        case "${live_dev}" in /dev/*) : ;; *) live_dev="$(blkid -L AIRWAVES_LIVE 2>/dev/null | head -1)" ;; esac
+        if [ -z "${live_dev}" ]; then
+            lm="$(sed -n 's/.*live-media=LABEL=\([^ ]*\).*/\1/p' /proc/cmdline 2>/dev/null)"
+            [ -n "${lm}" ] && live_dev="$(blkid -L "${lm}" 2>/dev/null | head -1)"
+        fi
+        if [ -n "${live_dev}" ]; then
+            SOURCE_DISK_NAME="$(lsblk -ndo pkname "${live_dev}" 2>/dev/null)"
+            [ -n "${SOURCE_DISK_NAME}" ] && { SOURCE_DISK="/dev/${SOURCE_DISK_NAME}"; return 0; }
+        fi
+        # toram + USB already removed: nothing to exclude (it can't be a target),
+        # so don't hard-fail — just mark the source unknown.
+        SOURCE_DISK_NAME=""; SOURCE_DISK="/dev/__live_in_ram__"; return 0
+    fi
+
     ROOT_UUID="$(sed -e 's/^.*root=//' -e 's/ .*$//' < /proc/cmdline)"
     ROOT_PART="$(blkid | tr -d '":' | grep -w "${ROOT_UUID#UUID=}" | awk '{print $1}' | head -1)"
     [ -z "${ROOT_PART}" ] && ROOT_PART="$(findmnt -no SOURCE / 2>/dev/null)"

--- a/armbian/userpatches/extensions/airwaves-os/scripts/airwaves-install
+++ b/armbian/userpatches/extensions/airwaves-os/scripts/airwaves-install
@@ -46,7 +46,16 @@ BOARD=""
 BOARDFAMILY=""
 ROOT_DEV=""    # target root partition device
 BOOT_DEV=""    # target ESP/firmware partition device (empty for uboot)
+AWCFG_DEV=""   # target AWCFG (FAT32 config) partition device — last partition
 TMP=""
+
+# Size reserved at the end of the disk for the AWCFG config partition (FAT32).
+# Kept well above the FAT32 minimum so mkfs.vfat -F32 never balks.
+AWCFG_END_RESERVE_MIB=100
+# Optional path to a provisioning config (hostname/wifi/channel/...) to seed onto
+# the target's AWCFG partition. Set via --config; written by airwaves-preconfig /
+# airwaves-firstrun. Destructive flags are always forced off on the target.
+INSTALL_CONFIG=""
 
 mkdir -p "${STATUS_DIR}"
 
@@ -130,6 +139,11 @@ discover_source() {
     ROOT_PART="$(blkid | tr -d '":' | grep -w "${ROOT_UUID#UUID=}" | awk '{print $1}' | head -1)"
     [ -z "${ROOT_PART}" ] && ROOT_PART="$(findmnt -no SOURCE / 2>/dev/null)"
     SOURCE_DISK_NAME="$(lsblk -ndo pkname "${ROOT_PART}" 2>/dev/null)"
+    # If we cannot resolve the parent disk, SOURCE_DISK would collapse to "/dev/"
+    # and the source/boot disk would NOT be excluded from candidate targets (it
+    # could then be offered as — or auto-resolved to — an install target and
+    # erased). Refuse instead. --list-json then returns nothing (fail-safe).
+    [ -n "${SOURCE_DISK_NAME}" ] || fail "cannot determine the source/boot disk (no parent for ${ROOT_PART:-?}); refusing to proceed"
     SOURCE_DISK="/dev/${SOURCE_DISK_NAME}"
 }
 
@@ -232,49 +246,53 @@ settle_parts() {
 
 # ---- partition + format: per platform --------------------------------------
 
-partition_x86() {  # GPT + FAT32 ESP(512MiB) + ext4 root
+partition_x86() {  # GPT + FAT32 ESP(512MiB) + ext4 root + FAT32 AWCFG(tail)
     phase "partitioning" 15
-    BOOT_DEV="$(part "${TARGET}" 1)"; ROOT_DEV="$(part "${TARGET}" 2)"
+    BOOT_DEV="$(part "${TARGET}" 1)"; ROOT_DEV="$(part "${TARGET}" 2)"; AWCFG_DEV="$(part "${TARGET}" 3)"
     if [ "${APPLY}" != "1" ]; then
-        log "[dry-run] wipefs ${TARGET}; gpt; ESP(${BOOT_DEV},fat32,512MiB); root(${ROOT_DEV},ext4,rest)"
+        log "[dry-run] wipefs ${TARGET}; gpt; ESP(${BOOT_DEV},fat32,512MiB); root(${ROOT_DEV},ext4,rest-${AWCFG_END_RESERVE_MIB}MiB); AWCFG(${AWCFG_DEV},fat32,${AWCFG_END_RESERVE_MIB}MiB tail)"
         return 0
     fi
     wipefs -a "${TARGET}" >>"${LOG_TMP}" 2>&1
     parted -s "${TARGET}" -- mklabel gpt >>"${LOG_TMP}" 2>&1 || fail "parted mklabel failed"
     parted -s "${TARGET}" -- mkpart "ESP" fat32 1MiB 513MiB >>"${LOG_TMP}" 2>&1 || fail "parted ESP failed"
     parted -s "${TARGET}" -- set 1 esp on >>"${LOG_TMP}" 2>&1
-    parted -s "${TARGET}" -- mkpart "airwaves-root" ext4 513MiB 100% >>"${LOG_TMP}" 2>&1 || fail "parted root failed"
-    settle_parts "${BOOT_DEV}" "${ROOT_DEV}"
+    parted -s "${TARGET}" -- mkpart "airwaves-root" ext4 513MiB "-${AWCFG_END_RESERVE_MIB}MiB" >>"${LOG_TMP}" 2>&1 || fail "parted root failed"
+    parted -s "${TARGET}" -- mkpart "AWCFG" fat32 "-${AWCFG_END_RESERVE_MIB}MiB" 100% >>"${LOG_TMP}" 2>&1 || fail "parted AWCFG failed"
+    settle_parts "${BOOT_DEV}" "${ROOT_DEV}" "${AWCFG_DEV}"
 
     phase "formatting" 25
     # FAT volume labels are limited to 11 characters.
     mkfs.vfat -F32 -n AIRWAVES "${BOOT_DEV}" >>"${LOG_TMP}" 2>&1 || fail "mkfs.vfat failed: $(tail -n3 "${LOG_TMP}" 2>/dev/null)"
     mkfs.ext4 -qF -L airwaves-root "${ROOT_DEV}" >>"${LOG_TMP}" 2>&1 || fail "mkfs.ext4 failed: $(tail -n3 "${LOG_TMP}" 2>/dev/null)"
+    mkfs.vfat -F32 -n AWCFG "${AWCFG_DEV}" >>"${LOG_TMP}" 2>&1 || fail "mkfs.vfat AWCFG failed: $(tail -n3 "${LOG_TMP}" 2>/dev/null)"
 }
 
-partition_uboot() {  # GPT + ext4 root starting at 16MiB (raw sectors hold u-boot)
+partition_uboot() {  # GPT + ext4 root at 16MiB + FAT32 AWCFG(tail); raw u-boot
     phase "partitioning" 15
-    BOOT_DEV=""; ROOT_DEV="$(part "${TARGET}" 1)"
+    BOOT_DEV=""; ROOT_DEV="$(part "${TARGET}" 1)"; AWCFG_DEV="$(part "${TARGET}" 2)"
     if [ "${APPLY}" != "1" ]; then
-        log "[dry-run] wipefs ${TARGET}; gpt; root(${ROOT_DEV},ext4,16MiB→rest); u-boot to raw sectors of ${TARGET}"
+        log "[dry-run] wipefs ${TARGET}; gpt; root(${ROOT_DEV},ext4,16MiB→rest-${AWCFG_END_RESERVE_MIB}MiB); AWCFG(${AWCFG_DEV},fat32,${AWCFG_END_RESERVE_MIB}MiB tail); u-boot to raw sectors of ${TARGET}"
         return 0
     fi
     wipefs -a "${TARGET}" >>"${LOG_TMP}" 2>&1
     parted -s "${TARGET}" -- mklabel gpt >>"${LOG_TMP}" 2>&1 || fail "parted mklabel failed"
     # Partition 1 starts at 16MiB, matching Armbian's OFFSET, leaving the 0–16MiB
     # region for the raw u-boot blobs written by write_uboot_platform.
-    parted -s "${TARGET}" -- mkpart "armbi_root" ext4 16MiB 100% >>"${LOG_TMP}" 2>&1 || fail "parted root failed"
-    settle_parts "${ROOT_DEV}"
+    parted -s "${TARGET}" -- mkpart "armbi_root" ext4 16MiB "-${AWCFG_END_RESERVE_MIB}MiB" >>"${LOG_TMP}" 2>&1 || fail "parted root failed"
+    parted -s "${TARGET}" -- mkpart "AWCFG" fat32 "-${AWCFG_END_RESERVE_MIB}MiB" 100% >>"${LOG_TMP}" 2>&1 || fail "parted AWCFG failed"
+    settle_parts "${ROOT_DEV}" "${AWCFG_DEV}"
 
     phase "formatting" 25
     mkfs.ext4 -qF -L armbi_root "${ROOT_DEV}" >>"${LOG_TMP}" 2>&1 || fail "mkfs.ext4 failed: $(tail -n3 "${LOG_TMP}" 2>/dev/null)"
+    mkfs.vfat -F32 -n AWCFG "${AWCFG_DEV}" >>"${LOG_TMP}" 2>&1 || fail "mkfs.vfat AWCFG failed: $(tail -n3 "${LOG_TMP}" 2>/dev/null)"
 }
 
-partition_rpi() {  # GPT + FAT32 /boot/firmware(512MiB) + ext4 root
+partition_rpi() {  # GPT + FAT32 /boot/firmware(512MiB) + ext4 root + FAT32 AWCFG(tail)
     phase "partitioning" 15
-    BOOT_DEV="$(part "${TARGET}" 1)"; ROOT_DEV="$(part "${TARGET}" 2)"
+    BOOT_DEV="$(part "${TARGET}" 1)"; ROOT_DEV="$(part "${TARGET}" 2)"; AWCFG_DEV="$(part "${TARGET}" 3)"
     if [ "${APPLY}" != "1" ]; then
-        log "[dry-run] wipefs ${TARGET}; gpt; firmware(${BOOT_DEV},fat32,512MiB,RPICFG); root(${ROOT_DEV},ext4,rest)"
+        log "[dry-run] wipefs ${TARGET}; gpt; firmware(${BOOT_DEV},fat32,512MiB,RPICFG); root(${ROOT_DEV},ext4,rest-${AWCFG_END_RESERVE_MIB}MiB); AWCFG(${AWCFG_DEV},fat32,${AWCFG_END_RESERVE_MIB}MiB tail)"
         return 0
     fi
     wipefs -a "${TARGET}" >>"${LOG_TMP}" 2>&1
@@ -282,12 +300,14 @@ partition_rpi() {  # GPT + FAT32 /boot/firmware(512MiB) + ext4 root
     parted -s "${TARGET}" -- mkpart "RPICFG" fat32 1MiB 513MiB >>"${LOG_TMP}" 2>&1 || fail "parted firmware failed"
     # The Raspberry Pi firmware boots a FAT data partition directly; the ESP flag
     # is intentionally NOT set (matches Armbian, which clears it for Pi 3/4).
-    parted -s "${TARGET}" -- mkpart "armbi_root" ext4 513MiB 100% >>"${LOG_TMP}" 2>&1 || fail "parted root failed"
-    settle_parts "${BOOT_DEV}" "${ROOT_DEV}"
+    parted -s "${TARGET}" -- mkpart "armbi_root" ext4 513MiB "-${AWCFG_END_RESERVE_MIB}MiB" >>"${LOG_TMP}" 2>&1 || fail "parted root failed"
+    parted -s "${TARGET}" -- mkpart "AWCFG" fat32 "-${AWCFG_END_RESERVE_MIB}MiB" 100% >>"${LOG_TMP}" 2>&1 || fail "parted AWCFG failed"
+    settle_parts "${BOOT_DEV}" "${ROOT_DEV}" "${AWCFG_DEV}"
 
     phase "formatting" 25
     mkfs.vfat -F32 -n RPICFG "${BOOT_DEV}" >>"${LOG_TMP}" 2>&1 || fail "mkfs.vfat failed: $(tail -n3 "${LOG_TMP}" 2>/dev/null)"
     mkfs.ext4 -qF -L armbi_root "${ROOT_DEV}" >>"${LOG_TMP}" 2>&1 || fail "mkfs.ext4 failed: $(tail -n3 "${LOG_TMP}" 2>/dev/null)"
+    mkfs.vfat -F32 -n AWCFG "${AWCFG_DEV}" >>"${LOG_TMP}" 2>&1 || fail "mkfs.vfat AWCFG failed: $(tail -n3 "${LOG_TMP}" 2>/dev/null)"
 }
 
 # ---- copy rootfs (rsync with live progress) --------------------------------
@@ -348,7 +368,19 @@ EOF
         local d; d="$(cat "${done}" 2>/dev/null)"; [ "${d}" != "no" ] && rc="${d}"
     done
     [ "${rc}" = "0" ] || fail "rootfs copy (rsync) failed with code ${rc}"
+    reset_firstboot_markers "${TMP}"
     PERCENT=80; write_status
+}
+
+# Reset first-boot state on the target so it re-initializes (fresh device id,
+# hostname, container load) and applies its AWCFG config on first boot. The
+# rsync copies the live system's markers (which may be in the post-init state),
+# so clear .initialized and arm .needs-first-run.
+reset_firstboot_markers() {
+    local root="$1"
+    mkdir -p "${root}/opt/airwaves" 2>/dev/null || true
+    rm -f "${root}/opt/airwaves/.initialized" 2>/dev/null || true
+    touch "${root}/opt/airwaves/.needs-first-run" 2>/dev/null || true
 }
 
 # ---- bootloader + fstab: per platform --------------------------------------
@@ -494,7 +526,7 @@ ab_slot_mib() {
 partition_x86_ab() {
     phase "partitioning" 15
     ESP_DEV="$(part "${TARGET}" 1)"; ROOTA_DEV="$(part "${TARGET}" 2)"
-    ROOTB_DEV="$(part "${TARGET}" 3)"; DATA_DEV="$(part "${TARGET}" 4)"
+    ROOTB_DEV="$(part "${TARGET}" 3)"; DATA_DEV="$(part "${TARGET}" 4)"; AWCFG_DEV="$(part "${TARGET}" 5)"
     local slot esp_end a_end b_end disk_mib
     slot="$(ab_slot_mib)"
     disk_mib=$(( $(blockdev --getsize64 "${TARGET}" 2>/dev/null || echo 0) / 1024 / 1024 ))
@@ -503,11 +535,12 @@ partition_x86_ab() {
     if [ "${disk_mib}" -lt 12288 ]; then
         fail "A/B needs a >=12 GiB disk (this disk is ${disk_mib}MiB). Install without --ab for a single-root system."
     fi
-    if [ "$(( b_end + 1024 ))" -ge "${disk_mib}" ]; then
-        fail "Disk too small for A/B (${disk_mib}MiB; need 2x${slot}MiB slots + data). Use a single-root install (omit --ab)."
+    # Reserve room for 2 slots + a >=1GiB data partition + the AWCFG tail.
+    if [ "$(( b_end + 1024 + AWCFG_END_RESERVE_MIB ))" -ge "${disk_mib}" ]; then
+        fail "Disk too small for A/B (${disk_mib}MiB; need 2x${slot}MiB slots + data + AWCFG). Use a single-root install (omit --ab)."
     fi
     if [ "${APPLY}" != "1" ]; then
-        log "[dry-run] gpt: ESP(1-513) rootA(513-${a_end}) rootB(${a_end}-${b_end}) data(${b_end}-100%); slot=${slot}MiB"
+        log "[dry-run] gpt: ESP(1-513) rootA(513-${a_end}) rootB(${a_end}-${b_end}) data(${b_end}-rest-${AWCFG_END_RESERVE_MIB}MiB) AWCFG(${AWCFG_END_RESERVE_MIB}MiB tail); slot=${slot}MiB"
         return 0
     fi
     wipefs -a "${TARGET}" >>"${LOG_TMP}" 2>&1
@@ -516,14 +549,16 @@ partition_x86_ab() {
     parted -s "${TARGET}" -- set 1 esp on >>"${LOG_TMP}" 2>&1
     parted -s "${TARGET}" -- mkpart "aw-root-a" ext4 513MiB "${a_end}MiB" >>"${LOG_TMP}" 2>&1 || fail "parted rootA failed"
     parted -s "${TARGET}" -- mkpart "aw-root-b" ext4 "${a_end}MiB" "${b_end}MiB" >>"${LOG_TMP}" 2>&1 || fail "parted rootB failed"
-    parted -s "${TARGET}" -- mkpart "aw-data" ext4 "${b_end}MiB" 100% >>"${LOG_TMP}" 2>&1 || fail "parted data failed"
-    settle_parts "${ESP_DEV}" "${ROOTA_DEV}" "${ROOTB_DEV}" "${DATA_DEV}"
+    parted -s "${TARGET}" -- mkpart "aw-data" ext4 "${b_end}MiB" "-${AWCFG_END_RESERVE_MIB}MiB" >>"${LOG_TMP}" 2>&1 || fail "parted data failed"
+    parted -s "${TARGET}" -- mkpart "AWCFG" fat32 "-${AWCFG_END_RESERVE_MIB}MiB" 100% >>"${LOG_TMP}" 2>&1 || fail "parted AWCFG failed"
+    settle_parts "${ESP_DEV}" "${ROOTA_DEV}" "${ROOTB_DEV}" "${DATA_DEV}" "${AWCFG_DEV}"
 
     phase "formatting" 25
     mkfs.vfat -F32 -n AIRWAVES "${ESP_DEV}" >>"${LOG_TMP}" 2>&1 || fail "mkfs.vfat failed: $(tail -n3 "${LOG_TMP}" 2>/dev/null)"
     mkfs.ext4 -qF -L aw-root-a "${ROOTA_DEV}" >>"${LOG_TMP}" 2>&1 || fail "mkfs rootA failed"
     mkfs.ext4 -qF -L aw-root-b "${ROOTB_DEV}" >>"${LOG_TMP}" 2>&1 || fail "mkfs rootB failed"
     mkfs.ext4 -qF -L aw-data   "${DATA_DEV}"  >>"${LOG_TMP}" 2>&1 || fail "mkfs data failed"
+    mkfs.vfat -F32 -n AWCFG    "${AWCFG_DEV}" >>"${LOG_TMP}" 2>&1 || fail "mkfs AWCFG failed: $(tail -n3 "${LOG_TMP}" 2>/dev/null)"
 }
 
 copy_rootfs_ab() {
@@ -568,6 +603,9 @@ EOF
         local d; d="$(cat "${done}" 2>/dev/null)"; [ "${d}" != "no" ] && rc="${d}"
     done
     [ "${rc}" = "0" ] || fail "rootfs copy (rsync) failed with code ${rc}"
+    # Clear/arm first-boot markers BEFORE cloning rootA -> rootB so both slots
+    # come up fresh and apply their AWCFG config on first boot.
+    reset_firstboot_markers "${TMP}"
 
     # Seed shared data: /data/{airwaves,docker}; relocate copied /etc/airwaves
     # into /data/airwaves (bind-mounted back via fstab).
@@ -576,7 +614,8 @@ EOF
     mount "${DATA_DEV}" "${DATAMNT}" || fail "mount data failed"
     mkdir -p "${DATAMNT}/airwaves" "${DATAMNT}/docker"
     if [ -d "${TMP}/etc/airwaves" ]; then
-        rsync -aHAX "${TMP}/etc/airwaves/" "${DATAMNT}/airwaves/" >>"${LOG_TMP}" 2>&1 || true
+        rsync -aHAX "${TMP}/etc/airwaves/" "${DATAMNT}/airwaves/" >>"${LOG_TMP}" 2>&1 \
+            || fail "failed to seed /data/airwaves from rootfs copy"
         rm -rf "${TMP}/etc/airwaves"/* 2>/dev/null || true
     fi
     mkdir -p "${TMP}/data" "${TMP}/etc/airwaves" "${TMP}/var/lib/docker"
@@ -629,6 +668,7 @@ bootloader_x86_ab() {
     mount "${ESP_DEV}" "${TMP}/boot/efi" || fail "mount ESP failed"
     for d in dev dev/pts proc sys run; do mount --bind "/${d}" "${TMP}/${d}"; done
     chroot "${TMP}" /bin/bash -c "grub-install --target=x86_64-efi --efi-directory=/boot/efi --boot-directory=/boot/efi --bootloader-id=Airwaves --removable" >>"${LOG_TMP}" 2>&1 \
+        || { sync; chroot "${TMP}" /bin/bash -c "grub-install --target=x86_64-efi --efi-directory=/boot/efi --boot-directory=/boot/efi --bootloader-id=Airwaves" >>"${LOG_TMP}" 2>&1; } \
         || fail "grub-install failed: $(tail -n3 "${LOG_TMP}" 2>/dev/null)"
 
     cat > "${TMP}/boot/efi/grub/grub.cfg" <<EOF
@@ -668,6 +708,57 @@ EOF
     REBOOT_REQUIRED="true"
 }
 
+# ---- AWCFG payload on the target -------------------------------------------
+# Produce the airwaves-install.json to place on the TARGET's AWCFG partition:
+# carry provisioning fields (hostname/wifi/channel/timezone/ssh) from the install
+# config when present, but FORCE every destructive flag OFF so the installed
+# system never auto-installs. Falls back to the shipped safe-default template.
+build_target_awcfg_config() {
+    local base="/opt/airwaves/config/awcfg/airwaves-install.json"
+    local j="{}"
+    [ -f "${base}" ] && j="$(cat "${base}" 2>/dev/null || echo '{}')"
+    # Guard a present-but-empty/corrupt template so the merge can't emit "".
+    jq -e . <<<"${j}" >/dev/null 2>&1 || j="{}"
+    if [ -n "${INSTALL_CONFIG}" ] && [ -f "${INSTALL_CONFIG}" ] && jq -e . "${INSTALL_CONFIG}" >/dev/null 2>&1; then
+        j="$(jq -n --argjson b "${j}" --slurpfile s "${INSTALL_CONFIG}" '
+            $b * {
+              hostname:  ($s[0].hostname  // ""),
+              wifi:     {ssid: ($s[0].wifi.ssid // ""), psk: ($s[0].wifi.psk // "")},
+              channel:   ($s[0].channel   // ""),
+              timezone:  ($s[0].timezone  // ""),
+              ssh_keys:  ($s[0].ssh_keys  // [])
+            }' 2>/dev/null || printf '%s' "${j}")"
+    fi
+    printf '%s' "${j}" | jq '.auto_install=false | .confirm_destructive=false | .self_install=false' 2>/dev/null \
+        || printf '%s' "${j}"
+}
+
+apply_awcfg_payload() {
+    [ -n "${AWCFG_DEV}" ] || return 0
+    if [ "${APPLY}" != "1" ]; then
+        log "[dry-run] write AWCFG config + README to ${AWCFG_DEV}"
+        return 0
+    fi
+    phase "config-partition" 97
+    local mp; mp="$(mktemp -d /mnt/airwaves-awcfg.XXXXXX)"
+    if ! mount "${AWCFG_DEV}" "${mp}" 2>>"${LOG_TMP}"; then
+        log "WARNING: could not mount AWCFG ${AWCFG_DEV}; skipping config payload"
+        rmdir "${mp}" 2>/dev/null || true
+        return 0
+    fi
+    local payload; payload="$(build_target_awcfg_config 2>>"${LOG_TMP}")"
+    if ! jq -e . <<<"${payload}" >/dev/null 2>&1; then
+        log "WARNING: built AWCFG config was invalid; writing safe default"
+        payload='{"auto_install":false,"confirm_destructive":false,"self_install":false}'
+    fi
+    printf '%s\n' "${payload}" > "${mp}/airwaves-install.json"
+    [ -f /opt/airwaves/config/awcfg/README.txt ] && cp /opt/airwaves/config/awcfg/README.txt "${mp}/README.txt" 2>/dev/null || true
+    sync
+    umount "${mp}" 2>/dev/null || umount -l "${mp}" 2>/dev/null || true
+    rmdir "${mp}" 2>/dev/null || true
+    log "Wrote AWCFG config partition payload to ${AWCFG_DEV}"
+}
+
 # ---- main ------------------------------------------------------------------
 
 AB=0
@@ -684,6 +775,7 @@ while [ $# -gt 0 ]; do
         --list-json) list_targets_json; exit 0 ;;
         --ab)        AB=1; shift ;;
         --target)    TARGET="${2:-}"; shift 2 ;;
+        --config)    INSTALL_CONFIG="${2:-}"; shift 2 ;;
         *)           TARGET="$1"; shift ;;
     esac
 done
@@ -702,6 +794,9 @@ case "${PLATFORM}" in
         partition_rpi;   copy_rootfs; bootloader_rpi ;;
     *)        fail "Unsupported platform: ${PLATFORM}" ;;
 esac
+
+# Seed the target's AWCFG config partition (applied by the target on first boot).
+apply_awcfg_payload
 
 STATE="success"
 PHASE="done"

--- a/armbian/userpatches/extensions/airwaves-os/scripts/airwaves-install
+++ b/armbian/userpatches/extensions/airwaves-os/scripts/airwaves-install
@@ -369,6 +369,8 @@ EOF
     done
     [ "${rc}" = "0" ] || fail "rootfs copy (rsync) failed with code ${rc}"
     reset_firstboot_markers "${TMP}"
+    phase "seeding-containers" 80
+    seed_target_containers "${TMP}"
     PERCENT=80; write_status
 }
 
@@ -381,6 +383,42 @@ reset_firstboot_markers() {
     mkdir -p "${root}/opt/airwaves" 2>/dev/null || true
     rm -f "${root}/opt/airwaves/.initialized" 2>/dev/null || true
     touch "${root}/opt/airwaves/.needs-first-run" 2>/dev/null || true
+}
+
+# Make the installed system bootable OFFLINE: docker-save the manager+gateway
+# images this live system is running into the target's /opt/airwaves/images so
+# the target's airwaves-init loads them on first boot (no registry pull). The
+# image's PRE-BAKED tarballs were already consumed (deleted) when THIS live USB
+# first booted, so the rsync copy carries an empty images dir — we recreate them
+# from the running docker here. Best-effort: if docker/images are unavailable the
+# target falls back to pulling online.
+seed_target_containers() {
+    local root="$1"
+    local imgdir="${root}/opt/airwaves/images"
+    local compose="/etc/airwaves/docker-compose.yml"
+    command -v docker >/dev/null 2>&1 || { log "docker unavailable; target will pull containers on first boot (needs network)"; return 0; }
+    [ -f "${compose}" ] || { log "no compose on live system; skipping container seed"; return 0; }
+    local refs
+    refs="$(grep -oE 'ghcr\.io/airframesio/airwaves-[a-z]+:[A-Za-z0-9._-]+' "${compose}" 2>/dev/null | sort -u)"
+    [ -n "${refs}" ] || { log "no airwaves image refs in compose; skipping container seed"; return 0; }
+    mkdir -p "${imgdir}" 2>/dev/null || true
+    local ref name ok=0
+    while IFS= read -r ref; do
+        [ -n "${ref}" ] || continue
+        if ! docker image inspect "${ref}" >/dev/null 2>&1; then
+            log "image ${ref} not present on live system; target will pull it"
+            continue
+        fi
+        name="$(printf '%s' "${ref}" | sed -E 's#^.*/##; s#[:/]#_#g')"
+        log "Seeding target container image: ${ref}"
+        if docker save -o "${imgdir}/${name}.tar" "${ref}" >>"${LOG_TMP}" 2>&1; then
+            ok=$((ok + 1))
+        else
+            log "WARNING: docker save failed for ${ref}"
+            rm -f "${imgdir}/${name}.tar" 2>/dev/null || true
+        fi
+    done <<< "${refs}"
+    log "Seeded ${ok} container image(s) into target ${imgdir}"
 }
 
 # ---- bootloader + fstab: per platform --------------------------------------
@@ -606,6 +644,9 @@ EOF
     # Clear/arm first-boot markers BEFORE cloning rootA -> rootB so both slots
     # come up fresh and apply their AWCFG config on first boot.
     reset_firstboot_markers "${TMP}"
+    # Seed offline container images into rootA before the clone so BOTH slots
+    # carry them.
+    seed_target_containers "${TMP}"
 
     # Seed shared data: /data/{airwaves,docker}; relocate copied /etc/airwaves
     # into /data/airwaves (bind-mounted back via fstab).

--- a/armbian/userpatches/extensions/airwaves-os/scripts/airwaves-install
+++ b/armbian/userpatches/extensions/airwaves-os/scripts/airwaves-install
@@ -171,6 +171,95 @@ list_targets_json() {
     echo "${rows}"
 }
 
+# Inspect one whole disk: read-only mount each partition to detect an existing
+# Airwaves OS install (via /etc/airwaves-release) or another OS (/etc/os-release),
+# and summarize the contents. Sets globals consumed by scan_targets_json:
+#   AW_PRESENT (true/false), AW_VER, AW_CODE, AW_LAYOUT, DISK_SUMMARY
+# Best-effort and always cleans up its mounts; needs root for the mounts.
+detect_disk_os() {
+    local disk="$1"
+    AW_PRESENT="false"; AW_VER=""; AW_CODE=""; AW_LAYOUT=""; DISK_SUMMARY=""
+    local os_name="" fstypes="" had_fs=0
+    local mp; mp="$(mktemp -d /tmp/aw-scan.XXXXXX 2>/dev/null)" || mp=""
+    local p fstype label existing inspect
+    # Partitions of this disk (raw NAME output; first line is the disk itself).
+    while IFS= read -r p; do
+        [ -n "$p" ] || continue
+        fstype="$(lsblk -nro FSTYPE "/dev/$p" 2>/dev/null | head -1)"
+        label="$(blkid -s LABEL -o value "/dev/$p" 2>/dev/null)"
+        [ -n "$fstype" ] && { had_fs=1; case " $fstypes " in *" $fstype "*) :;; *) fstypes="${fstypes:+$fstypes,}$fstype";; esac; }
+        case "$label" in
+            aw-root-a|aw-root-b) AW_LAYOUT="A/B" ;;
+            airwaves-root|armbi_root) [ -z "$AW_LAYOUT" ] && AW_LAYOUT="single" ;;
+        esac
+        # Only Linux roots can carry the release files; mount those read-only.
+        case "$fstype" in
+            ext4|ext3|ext2|btrfs) ;;
+            *) continue ;;
+        esac
+        [ -n "$mp" ] || continue
+        inspect=""; existing="$(findmnt -nro TARGET -S "/dev/$p" 2>/dev/null | head -1)"
+        if [ -n "$existing" ]; then
+            inspect="$existing"
+        elif timeout 10 mount -o ro,noload "/dev/$p" "$mp" 2>/dev/null \
+            || timeout 10 mount -o ro "/dev/$p" "$mp" 2>/dev/null; then
+            inspect="$mp"
+        fi
+        [ -n "$inspect" ] || continue
+        if [ -f "${inspect}/etc/airwaves-release" ]; then
+            AW_PRESENT="true"
+            AW_VER="$(awk -F= '/^AIRWAVES_VERSION=/{gsub(/"/,"",$2);print $2}' "${inspect}/etc/airwaves-release" 2>/dev/null)"
+            AW_CODE="$(awk -F= '/^AIRWAVES_CODENAME=/{gsub(/"/,"",$2);print $2}' "${inspect}/etc/airwaves-release" 2>/dev/null)"
+        elif [ -z "$os_name" ] && [ -f "${inspect}/etc/os-release" ]; then
+            os_name="$(awk -F= '/^PRETTY_NAME=/{gsub(/"/,"",$2);print $2}' "${inspect}/etc/os-release" 2>/dev/null)"
+        fi
+        [ "$inspect" = "$mp" ] && { umount "$mp" 2>/dev/null || umount -l "$mp" 2>/dev/null || true; }
+        [ "$AW_PRESENT" = "true" ] && break
+    done < <(lsblk -rno NAME "$disk" 2>/dev/null | tail -n +2)
+    [ -n "$mp" ] && rmdir "$mp" 2>/dev/null || true
+
+    if [ "$AW_PRESENT" = "true" ]; then
+        DISK_SUMMARY="Airwaves OS v${AW_VER:-?}${AW_LAYOUT:+ ${AW_LAYOUT}}"
+    elif [ -n "$os_name" ]; then
+        DISK_SUMMARY="$os_name"
+    elif [ "$had_fs" = "1" ]; then
+        DISK_SUMMARY="existing data (${fstypes})"
+    else
+        DISK_SUMMARY="empty / unpartitioned"
+    fi
+}
+
+# Like list_targets_json but enriched: partition-table type + a contents summary,
+# and whether each disk already holds an Airwaves OS install (with version),
+# confirmed by mounting. Used by the installer UI to inform the disk choice.
+# Heavier than --list-json (it mounts), so it is a separate verb.
+scan_targets_json() {
+    discover_source
+    local rows="[]"
+    local name rm type size model disk table
+    while read -r name rm type size model; do
+        [ "${type}" != "disk" ] && continue
+        [ "${rm}" = "1" ] && continue
+        [ "/dev/${name}" = "${SOURCE_DISK}" ] && continue
+        case "${name}" in sr*|loop*|ram*|zram*|fd*|dm-*|md*|nbd*) continue;; esac
+        disk="/dev/${name}"
+        table="$(lsblk -ndo PTTYPE "$disk" 2>/dev/null)"
+        [ -n "$table" ] || table="$(blkid -p -s PTTYPE -o value "$disk" 2>/dev/null)"
+        detect_disk_os "$disk"
+        rows="$(jq -c \
+            --arg dev "$disk" --arg size "${size}" --arg model "${model}" \
+            --arg table "${table:-unknown}" \
+            --argjson awpresent "${AW_PRESENT:-false}" \
+            --arg awver "${AW_VER:-}" --arg awcode "${AW_CODE:-}" --arg awlayout "${AW_LAYOUT:-}" \
+            --arg summary "${DISK_SUMMARY:-}" \
+            '. + [{device:$dev, size:$size, model:($model|gsub("^ +| +$";"")), table:$table,
+                   airwaves:{present:$awpresent, version:$awver, codename:$awcode, layout:$awlayout},
+                   summary:$summary}]' \
+            <<<"${rows}")"
+    done < <(lsblk -dno NAME,RM,TYPE,SIZE,MODEL)
+    echo "${rows}"
+}
+
 # ---- preflight guards ------------------------------------------------------
 
 preflight() {
@@ -809,11 +898,12 @@ if [ $# -eq 0 ]; then
     if [ -t 0 ] && command -v dialog >/dev/null 2>&1 && [ -x /opt/airwaves/scripts/airwaves-firstrun ]; then
         exec /opt/airwaves/scripts/airwaves-firstrun --install
     fi
-    fail "usage: airwaves-install [--ab] --target <disk> | --list-json"
+    fail "usage: airwaves-install [--ab] --target <disk> | --list-json | --scan-json"
 fi
 while [ $# -gt 0 ]; do
     case "$1" in
         --list-json) list_targets_json; exit 0 ;;
+        --scan-json) scan_targets_json; exit 0 ;;
         --ab)        AB=1; shift ;;
         --target)    TARGET="${2:-}"; shift 2 ;;
         --config)    INSTALL_CONFIG="${2:-}"; shift 2 ;;

--- a/armbian/userpatches/extensions/airwaves-os/scripts/airwaves-preconfig
+++ b/armbian/userpatches/extensions/airwaves-os/scripts/airwaves-preconfig
@@ -1,0 +1,220 @@
+#!/usr/bin/env bash
+#
+# airwaves-preconfig — apply declarative config from the AWCFG partition.
+#
+# The AWCFG FAT32 partition (label "AWCFG") carries airwaves-install.json. It
+# exists on the source install media AND on the installed system, but is only
+# consulted:
+#   * on FIRST setup (before /opt/airwaves/.initialized exists), or
+#   * on an already-initialized system ONLY when a file named "apply.conf" is
+#     also present on AWCFG (the re-arm trigger) — then it applies once and
+#     deletes apply.conf.
+#
+# This is the headless provisioning / recovery path (e.g. fix Wi-Fi on a
+# screenless device: edit airwaves-install.json, touch apply.conf, reboot).
+#
+# Phase 1 applies ONLY non-destructive settings (hostname, Wi-Fi, channel,
+# timezone, ssh keys). The destructive auto-install / self-install flags are
+# parsed but NOT acted on yet (a later phase wires them into the installer);
+# if set, we log and ignore so nothing is ever erased by this script.
+#
+# Runs as a systemd oneshot ordered before airwaves-init. Never fails the boot:
+# any problem logs a warning and exits 0, leaving the normal flow intact.
+#
+set -uo pipefail
+
+INITIALIZED="/opt/airwaves/.initialized"
+CONFIG_JSON="/etc/airwaves/config.json"
+VERSIONS="/etc/airwaves/.versions.json"
+MNT="/run/airwaves/awcfg"
+LOGF="/var/log/airwaves-preconfig.log"
+LABEL="AWCFG"
+
+log() {
+    echo "[airwaves-preconfig] $*"
+    logger -t airwaves-preconfig -- "$*" 2>/dev/null || true
+    echo "$(date -u +%Y-%m-%dT%H:%M:%SZ) $*" >> "$LOGF" 2>/dev/null || true
+}
+
+cleanup() {
+    if mountpoint -q "$MNT" 2>/dev/null; then
+        sync
+        umount "$MNT" 2>/dev/null || umount -l "$MNT" 2>/dev/null || true
+    fi
+}
+trap cleanup EXIT
+
+valid_hostname() {
+    local n="$1"
+    [ -n "$n" ] && [ "${#n}" -le 63 ] || return 1
+    [[ "$n" =~ ^[a-z0-9]([a-z0-9-]*[a-z0-9])?$ ]]
+}
+valid_timezone() {
+    local tz="$1"
+    [ -n "$tz" ] && [ "${#tz}" -le 64 ] && [[ "$tz" =~ ^[A-Za-z0-9/_+-]+$ ]]
+}
+
+# ---- locate AWCFG ----------------------------------------------------------
+DEV="$(blkid -L "$LABEL" 2>/dev/null | head -1)"
+if [ -z "$DEV" ]; then
+    # No config partition on this medium — nothing to do (normal for dev images).
+    exit 0
+fi
+
+# ---- decide whether to act -------------------------------------------------
+first_setup=1
+[ -f "$INITIALIZED" ] && first_setup=0
+
+mkdir -p "$MNT" 2>/dev/null || true
+mnt_rw=0
+if mount -o rw "$DEV" "$MNT" 2>/dev/null; then
+    mnt_rw=1
+elif mount -o ro "$DEV" "$MNT" 2>/dev/null; then
+    log "WARNING: ${DEV} (${LABEL}) mounted read-only; apply.conf may not be consumable"
+else
+    log "Could not mount ${DEV} (${LABEL}); skipping"
+    exit 0
+fi
+
+# Delete the apply.conf re-arm trigger so config applies once, not every boot.
+# If the FS is read-only, try to remount rw; if that fails, WARN loudly (the
+# config will otherwise re-apply on every boot).
+consume_apply_conf() {
+    [ "$rearm" -eq 1 ] || return 0
+    if [ "$mnt_rw" -ne 1 ]; then
+        mount -o remount,rw "$MNT" 2>/dev/null && mnt_rw=1
+    fi
+    if [ "$mnt_rw" -eq 1 ] && rm -f "${MNT}/apply.conf" 2>/dev/null; then
+        log "Consumed apply.conf (config applied once)"
+    else
+        log "WARNING: could not remove apply.conf (read-only ${LABEL}); config will re-apply next boot"
+    fi
+}
+
+cfg="${MNT}/airwaves-install.json"
+rearm=0
+[ -f "${MNT}/apply.conf" ] && rearm=1
+
+if [ "$first_setup" -eq 0 ] && [ "$rearm" -eq 0 ]; then
+    # Installed system, no apply.conf — AWCFG is inert. Do nothing.
+    exit 0
+fi
+
+if [ ! -f "$cfg" ]; then
+    log "No airwaves-install.json on ${LABEL}; nothing to apply"
+    consume_apply_conf
+    exit 0
+fi
+
+if ! jq -e . "$cfg" >/dev/null 2>&1; then
+    log "airwaves-install.json is not valid JSON; ignoring (safe fallback)"
+    # Leave apply.conf in place so the user can fix the JSON and retry.
+    exit 0
+fi
+
+if [ "$first_setup" -eq 1 ]; then
+    log "First-setup: applying config from ${LABEL} (${DEV})"
+else
+    log "apply.conf present: re-applying config from ${LABEL} (${DEV})"
+fi
+
+getstr() { jq -r "$1 // empty" "$cfg" 2>/dev/null; }
+
+# ---- hostname --------------------------------------------------------------
+hostname_v="$(getstr '.hostname' | tr 'A-Z' 'a-z')"
+if [ -n "$hostname_v" ]; then
+    if valid_hostname "$hostname_v"; then
+        log "Setting hostname: ${hostname_v}"
+        hostnamectl set-hostname "$hostname_v" 2>/dev/null || true
+        echo "$hostname_v" > /etc/hostname 2>/dev/null || true
+        if [ -f "$CONFIG_JSON" ]; then
+            tmp="$(jq --arg h "$hostname_v" '.device.hostname = $h' "$CONFIG_JSON" 2>/dev/null)" \
+                && [ -n "$tmp" ] && printf '%s\n' "$tmp" > "$CONFIG_JSON"
+        fi
+        systemctl restart avahi-daemon 2>/dev/null || true
+    else
+        log "WARNING: invalid hostname '${hostname_v}'; skipping"
+    fi
+fi
+
+# ---- wifi (NetworkManager) -------------------------------------------------
+wifi_ssid="$(getstr '.wifi.ssid')"
+wifi_psk="$(getstr '.wifi.psk')"
+if [ -n "$wifi_ssid" ]; then
+    if command -v nmcli >/dev/null 2>&1; then
+        log "Configuring Wi-Fi for SSID: ${wifi_ssid}"
+        nmcli radio wifi on >/dev/null 2>&1 || true
+        if [ -n "$wifi_psk" ]; then
+            if nmcli device wifi connect "$wifi_ssid" password "$wifi_psk" >/dev/null 2>&1; then
+                log "Wi-Fi connected: ${wifi_ssid}"
+            else
+                log "WARNING: Wi-Fi connect failed for ${wifi_ssid} (will remain a saved profile if created)"
+            fi
+        else
+            nmcli device wifi connect "$wifi_ssid" >/dev/null 2>&1 \
+                && log "Wi-Fi connected (open): ${wifi_ssid}" \
+                || log "WARNING: Wi-Fi connect failed for open SSID ${wifi_ssid}"
+        fi
+    else
+        log "WARNING: nmcli not present; cannot apply Wi-Fi"
+    fi
+fi
+
+# ---- update channel --------------------------------------------------------
+channel_v="$(getstr '.channel')"
+case "$channel_v" in
+    stable|beta|dev)
+        if [ -f "$VERSIONS" ]; then
+            tmp="$(jq --arg c "$channel_v" '.channel = $c' "$VERSIONS" 2>/dev/null)" \
+                && [ -n "$tmp" ] && printf '%s\n' "$tmp" > "$VERSIONS" \
+                && log "Update channel set: ${channel_v}"
+        fi
+        ;;
+    "") : ;;
+    *) log "WARNING: invalid channel '${channel_v}'; skipping" ;;
+esac
+
+# ---- timezone --------------------------------------------------------------
+tz_v="$(getstr '.timezone')"
+if [ -n "$tz_v" ]; then
+    if valid_timezone "$tz_v"; then
+        timedatectl set-timezone "$tz_v" 2>/dev/null && log "Timezone set: ${tz_v}" \
+            || log "WARNING: failed to set timezone '${tz_v}'"
+    else
+        log "WARNING: invalid timezone '${tz_v}'; skipping"
+    fi
+fi
+
+# ---- ssh keys (root + airwaves) -------------------------------------------
+mapfile -t ssh_keys < <(jq -r '.ssh_keys[]? // empty' "$cfg" 2>/dev/null)
+if [ "${#ssh_keys[@]}" -gt 0 ]; then
+    add_keys() {
+        local owner="$2" ak="$1/.ssh/authorized_keys" k added=0
+        mkdir -p "$1/.ssh" 2>/dev/null || return
+        touch "$ak" 2>/dev/null || return
+        for k in "${ssh_keys[@]}"; do
+            [ -n "$k" ] || continue
+            case "$k" in ssh-*|ecdsa-*|sk-ssh-*) ;; *) continue;; esac
+            grep -qxF "$k" "$ak" 2>/dev/null || { printf '%s\n' "$k" >> "$ak"; added=$((added+1)); }
+        done
+        chmod 700 "$1/.ssh" 2>/dev/null || true
+        chmod 600 "$ak" 2>/dev/null || true
+        chown -R "$owner" "$1/.ssh" 2>/dev/null || true
+        [ "$added" -gt 0 ] && log "Added ${added} SSH key(s) for ${owner}"
+    }
+    add_keys /root root
+    [ -d /home/airwaves ] && add_keys /home/airwaves airwaves
+fi
+
+# ---- destructive flags (NOT acted on in this phase) ------------------------
+auto_install="$(jq -r '.auto_install // false' "$cfg" 2>/dev/null)"
+self_install="$(jq -r '.self_install // false' "$cfg" 2>/dev/null)"
+if [ "$auto_install" = "true" ] || [ "$self_install" = "true" ]; then
+    log "NOTE: auto_install/self_install are set but unattended install is not enabled in this build; ignoring. Use the installer menu."
+fi
+
+# ---- consume the re-arm trigger -------------------------------------------
+consume_apply_conf
+
+log "Preconfig complete"
+exit 0

--- a/armbian/userpatches/extensions/airwaves-os/scripts/airwaves-preconfig
+++ b/armbian/userpatches/extensions/airwaves-os/scripts/airwaves-preconfig
@@ -29,6 +29,9 @@ VERSIONS="/etc/airwaves/.versions.json"
 MNT="/run/airwaves/awcfg"
 LOGF="/var/log/airwaves-preconfig.log"
 LABEL="AWCFG"
+INSTALL="/opt/airwaves/scripts/airwaves-install"
+TRIGGER="/run/airwaves/auto-install.json"          # consumed by airwaves-tui
+INSTALL_CFG_OUT="/run/airwaves/install-config.json" # provisioning cfg for the installer
 
 log() {
     echo "[airwaves-preconfig] $*"
@@ -52,6 +55,108 @@ valid_hostname() {
 valid_timezone() {
     local tz="$1"
     [ -n "$tz" ] && [ "${#tz}" -le 64 ] && [[ "$tz" =~ ^[A-Za-z0-9/_+-]+$ ]]
+}
+
+# Whole-disk device the running system booted from (e.g. /dev/sda, /dev/mmcblk0).
+source_disk() {
+    local ru rp
+    ru="$(sed -e 's/^.*root=//' -e 's/ .*$//' < /proc/cmdline 2>/dev/null)"
+    rp="$(blkid 2>/dev/null | tr -d '":' | grep -w "${ru#UUID=}" | awk '{print $1}' | head -1)"
+    [ -n "$rp" ] || rp="$(findmnt -no SOURCE / 2>/dev/null)"
+    local pk; pk="$(lsblk -ndo pkname "$rp" 2>/dev/null)"
+    [ -n "$pk" ] && echo "/dev/${pk}"
+}
+
+# Resolve the install target from a selector against the internal-disk list
+# (airwaves-install --list-json already excludes removable + the source disk).
+# "auto" requires EXACTLY ONE candidate; "largest" picks the biggest; a /dev path
+# must be present in the list. Prints the device, or returns non-zero (fail-safe).
+resolve_target() {
+    local want="$1" json n
+    json="$("${INSTALL}" --list-json 2>/dev/null)"
+    [ -n "$json" ] || return 1
+    n="$(echo "$json" | jq 'length' 2>/dev/null || echo 0)"
+    case "$want" in
+        auto)
+            [ "$n" = "1" ] || return 1
+            echo "$json" | jq -r '.[0].device'
+            ;;
+        largest)
+            [ "${n:-0}" -ge 1 ] 2>/dev/null || return 1
+            local d sz best="" bestsz=0
+            while read -r d; do
+                sz="$(blockdev --getsize64 "$d" 2>/dev/null || echo 0)"
+                [ "$sz" -gt "$bestsz" ] 2>/dev/null && { bestsz="$sz"; best="$d"; }
+            done < <(echo "$json" | jq -r '.[].device')
+            [ -n "$best" ] && echo "$best" || return 1
+            ;;
+        /dev/*)
+            echo "$json" | jq -e --arg d "$want" 'any(.[]; .device==$d)' >/dev/null 2>&1 || return 1
+            echo "$want"
+            ;;
+        *) return 1 ;;
+    esac
+}
+
+# On FIRST setup only, evaluate the destructive install gate and (if armed +
+# valid) write a trigger for airwaves-tui to perform the install. This function
+# NEVER erases anything itself; the actual install is gated behind the tui
+# consuming the trigger and the installer's AIRWAVES_INSTALL_APPLY=1.
+maybe_arm_install() {
+    local auto self confirm
+    auto="$(jq -r '.auto_install // false' "$cfg" 2>/dev/null)"
+    self="$(jq -r '.self_install // false' "$cfg" 2>/dev/null)"
+    confirm="$(jq -r '.confirm_destructive // false' "$cfg" 2>/dev/null)"
+
+    { [ "$auto" = "true" ] || [ "$self" = "true" ]; } || return 0
+
+    # Dual-key: destructive install requires explicit confirm_destructive=true.
+    if [ "$confirm" != "true" ]; then
+        log "auto/self-install requested WITHOUT confirm_destructive=true; ignoring (nothing will be erased)"
+        return 0
+    fi
+
+    local srcdisk src_removable=0
+    srcdisk="$(source_disk)"
+    if [ -z "$srcdisk" ]; then
+        log "cannot determine source disk; refusing to auto-arm an install (use the menu)"
+        return 0
+    fi
+    [ "$(cat "/sys/block/$(basename "$srcdisk")/removable" 2>/dev/null || echo 0)" = "1" ] && src_removable=1
+
+    local mode=""
+    if [ "$auto" = "true" ] && [ "$src_removable" = "1" ]; then
+        mode="usb-unattended"
+    elif [ "$self" = "true" ] && [ "$src_removable" = "0" ]; then
+        case "$(uname -m)" in x86_64) log "self_install ignored on x86 (use a live-USB auto_install)"; return 0;; esac
+        mode="sd-self-install"
+    else
+        log "install flags set but boot context doesn't match (auto_install needs removable media; self_install needs a fixed SD/eMMC source); ignoring"
+        return 0
+    fi
+
+    local want target ab
+    want="$(jq -r '.target // "auto"' "$cfg" 2>/dev/null)"; [ -n "$want" ] && [ "$want" != "null" ] || want="auto"
+    if ! target="$(resolve_target "$want")"; then
+        log "target '${want}' did not resolve to exactly one safe internal disk; NOT auto-installing (use the menu)"
+        return 0
+    fi
+    ab="$(jq -r '.ab // false' "$cfg" 2>/dev/null)"; [ "$ab" = "true" ] || ab="false"
+
+    local post; post="$(jq -r '.post_install // empty' "$cfg" 2>/dev/null)"
+    if [ "$post" != "reboot" ] && [ "$post" != "poweroff" ]; then
+        [ "$mode" = "sd-self-install" ] && post="reboot" || post="poweroff"
+    fi
+
+    mkdir -p /run/airwaves 2>/dev/null || true
+    cp "$cfg" "$INSTALL_CFG_OUT" 2>/dev/null || true
+    chmod 600 "$INSTALL_CFG_OUT" 2>/dev/null || true
+    jq -n --arg t "$target" --argjson ab "$ab" --arg mode "$mode" \
+          --arg post "$post" --arg src "${srcdisk:-}" --arg cfg "$INSTALL_CFG_OUT" \
+        '{target:$t, ab:$ab, mode:$mode, post_install:$post, source_disk:$src, config:$cfg}' \
+        > "$TRIGGER" 2>/dev/null \
+        && log "ARMED ${mode}: target=${target} ab=${ab} post=${post} (airwaves-tui will perform the install)" \
+        || log "WARNING: failed to write install trigger"
 }
 
 # ---- locate AWCFG ----------------------------------------------------------
@@ -206,11 +311,11 @@ if [ "${#ssh_keys[@]}" -gt 0 ]; then
     [ -d /home/airwaves ] && add_keys /home/airwaves airwaves
 fi
 
-# ---- destructive flags (NOT acted on in this phase) ------------------------
-auto_install="$(jq -r '.auto_install // false' "$cfg" 2>/dev/null)"
-self_install="$(jq -r '.self_install // false' "$cfg" 2>/dev/null)"
-if [ "$auto_install" = "true" ] || [ "$self_install" = "true" ]; then
-    log "NOTE: auto_install/self_install are set but unattended install is not enabled in this build; ignoring. Use the installer menu."
+# ---- destructive: unattended / self-install (FIRST SETUP ONLY) -------------
+# Never arm a destructive install from an apply.conf re-run on an already-set-up
+# system — apply.conf is only for non-destructive reconfig.
+if [ "$first_setup" -eq 1 ]; then
+    maybe_arm_install
 fi
 
 # ---- consume the re-arm trigger -------------------------------------------

--- a/armbian/userpatches/extensions/airwaves-os/scripts/airwaves-preconfig
+++ b/armbian/userpatches/extensions/airwaves-os/scripts/airwaves-preconfig
@@ -59,6 +59,20 @@ valid_timezone() {
 
 # Whole-disk device the running system booted from (e.g. /dev/sda, /dev/mmcblk0).
 source_disk() {
+    # Live-boot (USB installer, incl. toram): resolve the live medium, not "/".
+    if grep -qw 'boot=live' /proc/cmdline 2>/dev/null || [ -d /run/live/medium ]; then
+        local live_dev lm
+        live_dev="$(findmnt -no SOURCE /run/live/medium 2>/dev/null)"
+        case "${live_dev}" in /dev/*) : ;; *) live_dev="$(blkid -L AIRWAVES_LIVE 2>/dev/null | head -1)" ;; esac
+        if [ -z "${live_dev}" ]; then
+            lm="$(sed -n 's/.*live-media=LABEL=\([^ ]*\).*/\1/p' /proc/cmdline 2>/dev/null)"
+            [ -n "${lm}" ] && live_dev="$(blkid -L "${lm}" 2>/dev/null | head -1)"
+        fi
+        [ -n "${live_dev}" ] || return 1
+        local pk; pk="$(lsblk -ndo pkname "${live_dev}" 2>/dev/null)"
+        [ -n "$pk" ] && echo "/dev/${pk}"
+        return
+    fi
     local ru rp
     ru="$(sed -e 's/^.*root=//' -e 's/ .*$//' < /proc/cmdline 2>/dev/null)"
     rp="$(blkid 2>/dev/null | tr -d '":' | grep -w "${ru#UUID=}" | awk '{print $1}' | head -1)"

--- a/armbian/userpatches/extensions/airwaves-os/scripts/airwaves-tui
+++ b/armbian/userpatches/extensions/airwaves-os/scripts/airwaves-tui
@@ -145,18 +145,81 @@ center_lines() {
     done
 }
 # Console dimensions. A framebuffer console (x86 monitor) can be far wider/taller
-# than 80x25, so we can't rely on dialog auto-centering a multi-widget stack —
-# we compute a centered origin ourselves.
+# than 80x25, so we size + center every multi-widget stack from the live size.
 scr_cols() { local c; c="$(tput cols 2>/dev/null)"; { [ -n "$c" ] && [ "$c" -gt 0 ] 2>/dev/null; } && echo "$c" || echo 80; }
 scr_rows() { local r; r="$(tput lines 2>/dev/null)"; { [ -n "$r" ] && [ "$r" -gt 0 ] 2>/dev/null; } && echo "$r" || echo 25; }
-# Echo "<row> <col>" to top-left-anchor a stack of total height $1, width $2 so it
-# sits centered on the console.
-center_origin() {
-    local h="$1" w="$2" rows cols r c
-    rows="$(scr_rows)"; cols="$(scr_cols)"
-    r=$(( (rows - h) / 2 )); [ "$r" -lt 0 ] && r=0
-    c=$(( (cols - w) / 2 )); [ "$c" -lt 0 ] && c=0
-    echo "$r $c"
+# Box width: a generous slice of the console, capped for readability, floored so
+# it stays usable on an 80-col terminal. Used for both the splash centering and
+# the box geometry so they always agree.
+box_width() { local c w; c="$(scr_cols)"; w=$(( c * 92 / 100 )); [ "$w" -gt 92 ] && w=92; [ "$w" -lt 52 ] && w=52; echo "$w"; }
+
+# Adaptive geometry for a centered two-box stack (a splash infobox on top + a
+# menu or status box below). Grows the lower box to use spare vertical space (so
+# all actions show and the layout breathes on big screens), shrinks to fit on
+# small ones, and centers the whole stack. Echoes: "OX OY W TOPH BOTH LISTH".
+#   $1 = splash text (its line count sets the top box height)
+#   $2 = kind: "menu" (bottom is a --menu) or "info" (bottom is an --infobox)
+#   $3 = count: menu item count, or info content line count
+layout_stack() {
+    local splash="$1" kind="$2" count="$3"
+    local rows cols W topc toph chrome botmin both listh avail spare grow total oy ox
+    rows="$(scr_rows)"; cols="$(scr_cols)"; W="$(box_width)"
+    topc="$(printf '%s\n' "$splash" | wc -l | tr -d ' ')"
+    toph=$(( topc + 2 ))                 # content + borders (splash carries its own blank-line padding)
+    case "$kind" in
+        menu) chrome=6 ;;                # 2 borders + 2-line prompt + button + spacing
+        *)    chrome=2 ;;                # infobox: just borders
+    esac
+    botmin=$(( count + chrome ))
+    avail=$(( rows - 1 ))                # leave the backtitle row
+    both="$botmin"
+    spare=$(( avail - toph - botmin ))
+    if [ "$spare" -gt 0 ]; then
+        grow=$(( spare / 2 )); [ "$grow" -gt 6 ] && grow=6   # cap so big screens don't get a cavernous box
+        both=$(( both + grow ))
+    fi
+    total=$(( toph + both ))
+    if [ "$total" -gt "$avail" ]; then  # small terminal: shrink the lower box
+        both=$(( avail - toph )); [ "$both" -lt "$botmin" ] && both="$botmin"
+        total=$(( toph + both ))
+    fi
+    listh=$(( both - 6 )); [ "$listh" -lt "$count" ] && listh="$count"
+    oy=$(( (rows - total) / 2 )); [ "$oy" -lt 0 ] && oy=0
+    ox=$(( (cols - W) / 2 )); [ "$ox" -lt 0 ] && ox=0
+    echo "$ox $oy $W $toph $both $listh"
+}
+
+# Max splash content lines that leave room for the bottom box (so a small
+# terminal sheds splash padding/banner instead of clipping the menu).
+# $1 = kind (menu|info), $2 = bottom count (items or content lines).
+splash_budget() {
+    local rows avail chrome b
+    rows="$(scr_rows)"; avail=$(( rows - 1 ))
+    case "$1" in menu) chrome=6 ;; *) chrome=2 ;; esac
+    b=$(( avail - $2 - chrome - 2 )); [ "$b" -lt 4 ] && b=4
+    echo "$b"
+}
+
+# Assemble the splash (banner / details / optional Services) to fit within $2
+# content lines, dropping decorative pieces first on small terminals and adding
+# blank-line padding when there's room. $1 = inner width, $3 = 1 to include
+# the Services block.
+build_splash() {
+    local iw="$1" max="$2" with_svc="${3:-0}"
+    local details services banner bn base out_banner=0 out_pad=0
+    details="$(id_lines | sed 's/^  *//' | center_lines "$iw")"
+    [ "$with_svc" = 1 ] && services="$(services_block | center_block "$iw")"
+    banner="$(banner_art | center_block "$iw")"
+    bn="$(printf '%s\n' "$banner" | wc -l | tr -d ' ')"
+    base=3; [ "$with_svc" = 1 ] && base=$(( base + 4 ))
+    [ "$max" -ge $(( base + bn + 1 )) ] && out_banner=1
+    [ "$max" -ge $(( base + bn + 4 )) ] && out_pad=1
+    {
+        [ "$out_pad" = 1 ] && printf '\n'
+        if [ "$out_banner" = 1 ]; then printf '%s\n' "$banner"; [ "$out_pad" = 1 ] && printf '\n'; fi
+        printf '%s\n' "$details"
+        if [ "$with_svc" = 1 ]; then [ "$out_pad" = 1 ] && printf '\n'; printf '%s\n' "$services"; fi
+    }
 }
 
 # ---- generic dialogs -------------------------------------------------------
@@ -378,20 +441,22 @@ first_boot_screen() {
     [ -n "$step" ] || step="Starting first-boot setup..."
     # Banner (centered as a block) + details (each line centered) form the splash
     # ABOVE the box; the first-boot status goes INSIDE the titled box below.
-    splash="$( { banner_art | center_block 74; printf '\n'; id_lines | sed 's/^  *//' | center_lines 74; } )"
-    local oy ox
-    read -r oy ox < <(center_origin 20 78)   # 11 (splash) + 9 (status) = 20 high
+    local W iw splash status oy ox toph both lh botc maxs
+    W="$(box_width)"; iw=$(( W - 2 ))
+    status="$( { printf '\n'; \
+        printf '     First boot — preparing your device. This happens only once.\n\n'; \
+        printf '     > %s\n\n' "${step}"; \
+        printf '     Loading the app stack from the on-board copy (no network needed).\n'; \
+        printf '     The console menu appears automatically when ready.\n'; } )"
+    botc="$(printf '%s\n' "${status}" | wc -l | tr -d ' ')"
+    maxs="$(splash_budget info "${botc}")"
+    splash="$(build_splash "${iw}" "${maxs}" 0)"   # banner + details (no services here)
+    read -r ox oy W toph both lh < <(layout_stack "${splash}" info "${botc}")
     dlg --backtitle "${BT}" --no-collapse --keep-window \
-        --begin "${oy}" "${ox}" --no-shadow --infobox "${splash}" 11 78 \
+        --begin "${oy}" "${ox}" --no-shadow --infobox "${splash}" "${toph}" "${W}" \
         --and-widget --keep-window --no-shadow \
-        --begin "$((oy + 11))" "${ox}" --title "Setting up Airwaves OS" --infobox \
-"
-  First boot — preparing your device. This happens only once.
-
-  > ${step}
-
-  Loading the app stack from the on-board copy (no network needed).
-  The console menu appears automatically when ready." 9 78
+        --begin "$((oy + toph))" "${ox}" --title "Setting up Airwaves OS" \
+        --infobox "${status}" "${both}" "${W}"
     sleep 2
 }
 
@@ -489,13 +554,18 @@ while true; do
     # banner is centered as a block; the detail/status lines are each centered.
     # Banner (block-centered) + details (line-centered) + a vertical Services
     # list (block-centered so its column stays aligned).
-    splash="$( { banner_art | center_block 74; id_lines | sed 's/^  *//' | center_lines 74; services_block | center_block 74; } )"
-    read -r oy ox < <(center_origin 24 76)   # 14 (banner) + 10 (menu) = 24 high
+    # Adaptive, centered, padded layout: splash on top, action menu below sized to
+    # show every action and grow/shrink with the terminal.
+    W="$(box_width)"; iw=$(( W - 2 ))
+    nitems=$(( ${#items[@]} / 2 ))
+    maxs="$(splash_budget menu "${nitems}")"
+    splash="$(build_splash "${iw}" "${maxs}" 1)"   # banner + details + Services
+    read -r ox oy W toph both lh < <(layout_stack "${splash}" menu "${nitems}")
     choice="$(dlg --backtitle "${BT}" --no-collapse --keep-window \
-        --begin "${oy}" "${ox}" --no-shadow --infobox "${splash}" 14 76 \
+        --begin "${oy}" "${ox}" --no-shadow --infobox "${splash}" "${toph}" "${W}" \
         --and-widget --keep-window --no-shadow --no-cancel \
-        --begin "$((oy + 14))" "${ox}" --title "Airwaves OS Console" \
-        --menu "Select an action:" 10 76 6 "${items[@]}" \
+        --begin "$((oy + toph))" "${ox}" --title "Airwaves OS Console" \
+        --menu "\n  Select an action:" "${both}" "${W}" "${lh}" "${items[@]}" \
         3>&1 1>&2 2>&3)" || { sleep 1; continue; }
 
     case "$choice" in

--- a/armbian/userpatches/extensions/airwaves-os/scripts/airwaves-tui
+++ b/armbian/userpatches/extensions/airwaves-os/scripts/airwaves-tui
@@ -1,9 +1,15 @@
 #!/bin/bash
 #
 # airwaves-tui — the persistent Airwaves OS console menu shown on the main VT
-# (tty1). Renders a banner + live status and offers actions appropriate to the
-# system: a LIVE USB emphasises Install; an INSTALLED system offers Configuration
-# (driven via the manager API, like the web UI), Upgrade, Repair, etc.
+# (tty1). Renders a colorful banner box + live status and offers actions
+# appropriate to the system: a LIVE USB emphasises Install; an INSTALLED system
+# offers Configuration, Upgrade, Repair, etc.
+#
+# Configuration is driven through the manager API (like the web UI) whenever the
+# manager is reachable. If the manager is NOT responding, Config offers a local
+# RESCUE fallback for Wi-Fi (and a couple of other basics) using host tools
+# (nmcli/hostnamectl), after warning the operator that direct changes bypass the
+# manager and may need reconciliation once it is back up.
 #
 # Launched from the tty1 autologin session (see /etc/profile.d/zz-airwaves-tui.sh
 # + the getty@tty1 autologin drop-in). It LOOPS FOREVER — every action returns to
@@ -16,9 +22,47 @@ FIRSTRUN="/opt/airwaves/scripts/airwaves-firstrun"   # the install sub-flow (--i
 API="http://localhost/api/v1"                         # manager API via the gateway
 VERSIONS="/etc/airwaves/.versions.json"
 RELEASE="/etc/airwaves-release"
+FIRSTRUN_MARKER="/opt/airwaves/.needs-first-run"
 BT="Airwaves OS"
-export DIALOGRC=/dev/null
 export TERM="${TERM:-linux}"
+
+# A black/cyan dialog theme so the console reads as a branded appliance screen
+# (the banner box and menu share one cohesive black background). Written to
+# tmpfs at startup; falls back to the stock theme if it can't be created.
+AWRC="/run/airwaves-tui.dialogrc"
+init_theme() {
+    cat > "$AWRC" 2>/dev/null <<'RC' || { AWRC="/dev/null"; return; }
+use_shadow = OFF
+use_colors = ON
+screen_color = (CYAN,BLACK,ON)
+dialog_color = (CYAN,BLACK,ON)
+title_color = (YELLOW,BLACK,ON)
+border_color = (CYAN,BLACK,ON)
+border2_color = (CYAN,BLACK,ON)
+menubox_color = (WHITE,BLACK,OFF)
+menubox_border_color = (CYAN,BLACK,ON)
+menubox_border2_color = (CYAN,BLACK,ON)
+item_color = (WHITE,BLACK,OFF)
+item_selected_color = (BLACK,CYAN,ON)
+tag_color = (YELLOW,BLACK,ON)
+tag_selected_color = (BLACK,CYAN,ON)
+tag_key_color = (YELLOW,BLACK,OFF)
+tag_key_selected_color = (BLACK,CYAN,ON)
+button_active_color = (BLACK,CYAN,ON)
+button_inactive_color = (CYAN,BLACK,OFF)
+button_key_active_color = (BLACK,CYAN,ON)
+button_key_inactive_color = (YELLOW,BLACK,OFF)
+button_label_active_color = (BLACK,CYAN,ON)
+button_label_inactive_color = (CYAN,BLACK,ON)
+inputbox_color = (WHITE,BLACK,OFF)
+inputbox_border_color = (CYAN,BLACK,ON)
+searchbox_color = (WHITE,BLACK,OFF)
+position_indicator_color = (YELLOW,BLACK,ON)
+gauge_color = (CYAN,BLACK,ON)
+RC
+}
+# Run dialog with the branded theme (used for the main console + sub-dialogs).
+dlg() { DIALOGRC="$AWRC" dialog "$@"; }
 
 # ---- status helpers (all bounded so the menu never hangs) -------------------
 api_up()    { curl -fsS -m3 "${API}/system/overview" >/dev/null 2>&1; }
@@ -40,8 +84,8 @@ is_live() {
     rd="$(lsblk -ndo pkname "$(findmnt -no SOURCE / 2>/dev/null)" 2>/dev/null)"
     [ "$(cat "/sys/block/${rd}/removable" 2>/dev/null || echo 0)" = "1" ]
 }
-# Bounded: on first boot dockerd is busy pulling, so an unbounded `docker inspect`
-# could block the menu for minutes. Cap it.
+# Bounded: on first boot dockerd is busy loading images, so an unbounded
+# `docker inspect` could block the menu for minutes. Cap it.
 svc() {
     local s
     s="$(timeout 3 docker inspect -f '{{if .State.Health}}{{.State.Health.Status}}{{else}}{{.State.Status}}{{end}}' "$1" 2>/dev/null)" || s="starting"
@@ -49,80 +93,144 @@ svc() {
 }
 release_var() { [ -f "$RELEASE" ] && awk -F= "/^$1=/{gsub(/\"/,\"\",\$2);print \$2}" "$RELEASE" 2>/dev/null; }
 
-banner() {
-    # Compact branded banner; toilet is in the base image (used by the MOTD).
+# ---- banner / identity (split so the first-boot screen can skip docker) -----
+banner_art() {
     if command -v toilet >/dev/null 2>&1; then
-        toilet -f small "Airwaves OS" 2>/dev/null || echo "Airwaves OS"
+        toilet -f small "Airwaves OS" 2>/dev/null || echo "  Airwaves OS"
     else
-        echo "Airwaves OS"
+        echo "  Airwaves OS"
     fi
 }
-
-header() {
-    local ver cn ch host ip mode up
+id_lines() {
+    local ver cn ch host ip mode
     ver="$(release_var AIRWAVES_VERSION)"; ver="${ver:-?}"
     cn="$(release_var AIRWAVES_CODENAME)"
     ch="$(jq -r '.channel // "stable"' "$VERSIONS" 2>/dev/null || echo stable)"
     host="$(hostname 2>/dev/null)"; ip="$(primary_ip)"
     if is_live; then mode="LIVE USB"; else mode="INSTALLED"; fi
+    printf '  Airwaves OS v%s  %s   ·   %s   ·   channel: %s\n' "$ver" "$cn" "$mode" "$ch"
+    printf '  Host: %s' "$host"; [ -n "$ip" ] && printf '    IP: %s' "$ip"; printf '\n'
+    printf '  Web UI: http://%s.local' "$host"; [ -n "$ip" ] && printf '   /   http://%s' "$ip"; printf '\n'
+}
+stack_line() {
+    local up
     up="$(awk '{d=int($1/86400);h=int(($1%86400)/3600);m=int(($1%3600)/60); if(d)printf "%dd %dh %dm",d,h,m; else if(h)printf "%dh %dm",h,m; else printf "%dm",m}' /proc/uptime 2>/dev/null)"
-    banner
-    printf '  v%s %s   ·   %s   ·   channel: %s\n' "$ver" "$cn" "$mode" "$ch"
-    printf '\n'
-    printf '  Host:    %s' "$host"; [ -n "$ip" ] && printf '    IP: %s' "$ip"; printf '\n'
-    printf '  Web UI:  http://%s.local' "$host"; [ -n "$ip" ] && printf '  /  http://%s' "$ip"; printf '\n'
-    printf '  Stack:   manager=%s  gateway=%s    Uptime: %s\n' "$(svc airwaves-manager)" "$(svc airwaves-gateway)" "${up:-?}"
+    printf '  manager: %s   gateway: %s   ·   uptime: %s\n' "$(svc airwaves-manager)" "$(svc airwaves-gateway)" "${up:-?}"
 }
 
-msg()  { dialog --backtitle "${BT}" --title "$1" --msgbox "$2" "${3:-10}" "${4:-64}"; }
-need_api() { api_up && return 0; msg "Manager unavailable" "\nThe manager service isn't responding yet.\n\nTry again in a moment, or use 'Open a shell' to investigate." 11 60; return 1; }
+# ---- generic dialogs -------------------------------------------------------
+msg()  { dlg --backtitle "${BT}" --title "$1" --msgbox "$2" "${3:-10}" "${4:-64}"; }
+need_api() { api_up && return 0; msg "Manager unavailable" "\nThe manager service isn't responding, and this action requires it.\n\nTry again in a moment, or use 'Open a shell' to investigate." 11 62; return 1; }
 
-# ---- Configuration submenu (installed systems) -----------------------------
-cfg_hostname() {
-    need_api || return
-    local cur new
-    cur="$(api_get /system/info | jq -r '.hostname // empty' 2>/dev/null)"; cur="${cur:-$(hostname)}"
-    new="$(dialog --backtitle "${BT}" --title "Hostname" --inputbox "\nDevice hostname (letters, digits, hyphens):" 10 60 "${cur}" 3>&1 1>&2 2>&3)" || return
-    [ -n "${new}" ] || { msg "Hostname" "\nHostname cannot be empty."; return; }
-    if api_post /system/hostname "{\"hostname\":\"${new}\"}" >/dev/null; then
-        msg "Hostname" "\nHostname set to: ${new}"
-    else
-        msg "Hostname" "\nFailed to set hostname (the manager rejected it or is unavailable)."
-    fi
+# Warn the operator before a local (rescue) change that bypasses the manager.
+# Returns 0 to proceed, 1 to cancel.
+rescue_warn() {
+    dlg --backtitle "${BT}" --title "Manager not running — rescue mode" --defaultno --yesno \
+"\nThe manager service isn't responding, so '$1' can't be set the normal way (through the manager, like the web UI).\n\nYou can configure it DIRECTLY now as a rescue:\n\n  * Changes apply to the host immediately.\n  * They BYPASS the manager and may differ from what the\n    manager shows once it comes back up.\n  * The manager reconciles/observes them on its next start.\n\nProceed with direct (rescue) configuration?" 18 70
 }
-cfg_wifi() {
-    need_api || return
-    dialog --backtitle "${BT}" --infobox "\nScanning for Wi-Fi networks..." 5 40;
-    local json rows=() ssid
+
+# ---- Wi-Fi: API path + local nmcli rescue path -----------------------------
+cfg_wifi_api() {
+    dlg --backtitle "${BT}" --infobox "\nScanning for Wi-Fi networks..." 5 44
+    local json rows=() ssid pw
     json="$(api_get /wifi/scan)"
-    [ -n "${json}" ] || { msg "Wi-Fi" "\nNo Wi-Fi interface found, or scan failed.\n\n(Wired Ethernet needs no configuration.)" 11 60; return; }
-    while IFS= read -r ssid; do [ -n "$ssid" ] && rows+=("$ssid" ""); done < <(echo "${json}" | jq -r '.[].ssid // empty' 2>/dev/null | sort -u)
+    [ -n "${json}" ] || { msg "Wi-Fi" "\nNo Wi-Fi interface found, or the scan failed.\n\n(Wired Ethernet needs no configuration.)" 11 62; return; }
+    while IFS= read -r ssid; do [ -n "$ssid" ] && rows+=("$ssid" ""); done \
+        < <(echo "${json}" | jq -r '.[].ssid // empty' 2>/dev/null | awk 'NF' | sort -u)
     [ "${#rows[@]}" -gt 0 ] || { msg "Wi-Fi" "\nNo networks found in range."; return; }
-    ssid="$(dialog --backtitle "${BT}" --title "Wi-Fi networks" --menu "\nSelect a network:" 18 60 10 "${rows[@]}" 3>&1 1>&2 2>&3)" || return
-    local pw
-    pw="$(dialog --backtitle "${BT}" --title "Wi-Fi password" --insecure --passwordbox "\nPassword for ${ssid} (blank for open):" 10 60 3>&1 1>&2 2>&3)" || return
-    dialog --backtitle "${BT}" --infobox "\nConnecting to ${ssid}..." 5 40
+    ssid="$(dlg --backtitle "${BT}" --title "Wi-Fi networks" --menu "\nSelect a network:" 18 60 10 "${rows[@]}" 3>&1 1>&2 2>&3)" || return
+    pw="$(dlg --backtitle "${BT}" --title "Wi-Fi password" --insecure --passwordbox "\nPassword for ${ssid} (blank for open):" 10 60 3>&1 1>&2 2>&3)" || return
+    dlg --backtitle "${BT}" --infobox "\nConnecting to ${ssid}..." 5 44
     if api_post /wifi/connect "{\"ssid\":\"${ssid}\",\"password\":\"${pw}\"}" >/dev/null; then
         msg "Wi-Fi" "\nConnect request sent for: ${ssid}"
     else
         msg "Wi-Fi" "\nFailed to connect to ${ssid}."
     fi
 }
+cfg_wifi_local() {
+    command -v nmcli >/dev/null 2>&1 || { msg "Wi-Fi" "\nNetworkManager (nmcli) is not available, so a direct rescue connect isn't possible on this image."; return; }
+    dlg --backtitle "${BT}" --infobox "\nScanning for Wi-Fi networks (direct / nmcli)..." 5 52
+    local rows=() ssid pw out
+    # nmcli --terse escapes ':' as '\:' and '\' as '\\'; unescape via placeholder.
+    while IFS= read -r ssid; do [ -n "$ssid" ] && rows+=("$ssid" ""); done \
+        < <(nmcli -t -f SSID device wifi list --rescan yes 2>/dev/null \
+            | sed -e 's/\\\\/\x01/g' -e 's/\\:/:/g' -e 's/\x01/\\/g' | awk 'NF' | sort -u)
+    [ "${#rows[@]}" -gt 0 ] || { msg "Wi-Fi" "\nNo Wi-Fi networks found (or no Wi-Fi adapter).\n\n(Wired Ethernet needs no configuration.)" 11 62; return; }
+    ssid="$(dlg --backtitle "${BT}" --title "Wi-Fi networks (rescue)" --menu "\nSelect a network:" 18 60 10 "${rows[@]}" 3>&1 1>&2 2>&3)" || return
+    pw="$(dlg --backtitle "${BT}" --title "Wi-Fi password (rescue)" --insecure --passwordbox "\nPassword for ${ssid} (blank for open):" 10 60 3>&1 1>&2 2>&3)" || return
+    dlg --backtitle "${BT}" --infobox "\nConnecting to ${ssid} (direct / nmcli)..." 5 52
+    nmcli radio wifi on >/dev/null 2>&1 || true
+    local rc
+    if [ -n "${pw}" ]; then
+        out="$(nmcli device wifi connect "${ssid}" password "${pw}" 2>&1)"; rc=$?
+    else
+        out="$(nmcli device wifi connect "${ssid}" 2>&1)"; rc=$?
+    fi
+    if [ "$rc" -eq 0 ]; then
+        msg "Wi-Fi (rescue)" "\nConnected directly to: ${ssid}\n\nThis bypassed the manager. It will reconcile this\nconnection the next time it starts." 11 64
+    else
+        msg "Wi-Fi (rescue)" "\nFailed to connect to ${ssid}.\n\n${out}" 12 64
+    fi
+}
+cfg_wifi() {
+    if api_up; then cfg_wifi_api; else rescue_warn "Wi-Fi" && cfg_wifi_local; fi
+}
+
+# ---- hostname: API path + local hostnamectl rescue -------------------------
+cfg_hostname() {
+    local cur new
+    if api_up; then
+        cur="$(api_get /system/info | jq -r '.hostname // empty' 2>/dev/null)"; cur="${cur:-$(hostname)}"
+        new="$(dlg --backtitle "${BT}" --title "Hostname" --inputbox "\nDevice hostname (letters, digits, hyphens):" 10 60 "${cur}" 3>&1 1>&2 2>&3)" || return
+        [ -n "${new}" ] || { msg "Hostname" "\nHostname cannot be empty."; return; }
+        if api_post /system/hostname "{\"hostname\":\"${new}\"}" >/dev/null; then
+            msg "Hostname" "\nHostname set to: ${new}"
+        else
+            msg "Hostname" "\nFailed to set hostname (the manager rejected it or is unavailable)."
+        fi
+    else
+        rescue_warn "Hostname" || return
+        cur="$(hostname)"
+        new="$(dlg --backtitle "${BT}" --title "Hostname (rescue)" --inputbox "\nDevice hostname (letters, digits, hyphens):" 10 60 "${cur}" 3>&1 1>&2 2>&3)" || return
+        [ -n "${new}" ] || { msg "Hostname" "\nHostname cannot be empty."; return; }
+        if hostnamectl set-hostname "${new}" 2>/dev/null; then
+            echo "${new}" > /etc/hostname 2>/dev/null || true
+            systemctl restart avahi-daemon 2>/dev/null || true
+            msg "Hostname (rescue)" "\nHostname set directly to: ${new}\n\nThis bypassed the manager." 10 60
+        else
+            msg "Hostname (rescue)" "\nFailed to set hostname directly."
+        fi
+    fi
+}
+
+# ---- update channel: API path + local .versions.json rescue ----------------
 cfg_channel() {
-    need_api || return
     local cur new
     cur="$(jq -r '.channel // "stable"' "$VERSIONS" 2>/dev/null || echo stable)"
-    new="$(dialog --backtitle "${BT}" --title "Update channel" --default-item "${cur}" \
+    new="$(dlg --backtitle "${BT}" --title "Update channel" --default-item "${cur}" \
         --menu "\nCurrent: ${cur}\n\nChoose the update channel:" 14 60 3 \
         stable "Tested releases (recommended)" \
         beta   "Pre-release candidates" \
         dev    "Latest development builds" 3>&1 1>&2 2>&3)" || return
-    if api_post /system/update/channel "{\"channel\":\"${new}\"}" >/dev/null; then
-        msg "Update channel" "\nChannel set to: ${new}\n\nUse Upgrade to apply the latest on this channel."
+    if api_up; then
+        if api_post /system/update/channel "{\"channel\":\"${new}\"}" >/dev/null; then
+            msg "Update channel" "\nChannel set to: ${new}\n\nUse Upgrade to apply the latest on this channel."
+        else
+            msg "Update channel" "\nFailed to set channel."
+        fi
     else
-        msg "Update channel" "\nFailed to set channel."
+        rescue_warn "Update channel" || return
+        local tmp
+        tmp="$(jq -c --arg c "${new}" '.channel = $c' "$VERSIONS" 2>/dev/null)"
+        if [ -n "${tmp}" ] && printf '%s\n' "${tmp}" > "${VERSIONS}" 2>/dev/null; then
+            msg "Update channel (rescue)" "\nChannel set directly to: ${new}\n\nThis bypassed the manager." 10 60
+        else
+            msg "Update channel (rescue)" "\nFailed to write ${VERSIONS}."
+        fi
     fi
 }
+
+# ---- password (always local: PAM) ------------------------------------------
 cfg_password() {
     clear
     echo "== Change the 'airwaves' user password =="
@@ -133,10 +241,12 @@ cfg_password() {
     case "$a" in y|Y) passwd root || true;; esac
     echo; read -r -p "Press ENTER to return to the menu..." _
 }
+
+# ---- Airframes feeder token (manager only) ---------------------------------
 cfg_airframes() {
     need_api || return
     local tok cfg
-    tok="$(dialog --backtitle "${BT}" --title "Airframes feeder token (optional)" --insecure --passwordbox \
+    tok="$(dlg --backtitle "${BT}" --title "Airframes feeder token (optional)" --insecure --passwordbox \
         "\nPaste your Airframes.io feeder token/API key to share data with the\nAirframes network. Leave blank to skip.\n\n(Account username/password login is coming in a later update.)" 13 66 3>&1 1>&2 2>&3)" || return
     [ -n "${tok}" ] || return
     cfg="$(api_get /config)"; [ -n "${cfg}" ] || { msg "Airframes" "\nCould not read current config."; return; }
@@ -147,11 +257,13 @@ cfg_airframes() {
         msg "Airframes" "\nFailed to save the token."
     fi
 }
+
 configuration_menu() {
+    local hint c
+    if api_up; then hint="applied via the manager, like the web UI"; else hint="MANAGER DOWN — Wi-Fi/hostname/channel offer a direct rescue"; fi
     while true; do
-        local c
-        c="$(dialog --backtitle "${BT}" --title "Configuration" --cancel-label "Back" \
-            --menu "\nConfigure this device (applied via the manager, like the web UI):" 16 64 7 \
+        c="$(dlg --backtitle "${BT}" --title "Configuration" --cancel-label "Back" \
+            --menu "\nConfigure this device (${hint}):" 16 70 7 \
             hostname  "Change hostname" \
             wifi      "Configure wireless (Wi-Fi)" \
             channel   "Change update channel" \
@@ -182,7 +294,7 @@ update_gauge() {
             sleep 2
         done
         echo 100
-    ) | dialog --backtitle "$BT" --title "$1" --gauge "\nStarting..." 10 64 0
+    ) | dlg --backtitle "$BT" --title "$1" --gauge "\nStarting..." 10 64 0
 }
 apply_update() {   # $1 = upgrade | repair
     need_api || return
@@ -209,9 +321,39 @@ open_shell() {
     AIRWAVES_TUI_SHELL=1 bash -l || true
 }
 
+# ---- first-boot status screen (#20) ----------------------------------------
+# While first-boot init is still running, show what it's doing instead of a
+# half-working menu. airwaves-init logs each step to its journal; we surface the
+# latest line. The marker is removed when init finalizes, so this falls through
+# to the menu automatically. If init FAILED, we skip this and show the menu so
+# the operator can open a shell / repair.
+first_boot_active() {
+    [ -f "$FIRSTRUN_MARKER" ] && ! systemctl is-failed --quiet airwaves-init.service 2>/dev/null
+}
+first_boot_screen() {
+    local step
+    step="$(journalctl -u airwaves-init.service -o cat --no-pager 2>/dev/null | awk 'NF' | tail -1)"
+    step="${step#\[airwaves-init\] }"
+    [ -n "$step" ] || step="Starting first-boot setup..."
+    dlg --backtitle "${BT}" --no-collapse --title "Setting up Airwaves OS" --infobox \
+"$(banner_art)
+$(id_lines)
+  First boot — preparing your device. This happens only once.
+
+  > ${step}
+
+  Loading the app stack from the on-board copy (no network needed).
+  The console menu appears automatically when ready." 20 78
+    sleep 2
+}
+
 command -v dialog >/dev/null 2>&1 || { echo "dialog not available; opening a shell."; exec bash -l; }
+init_theme
 
 while true; do
+    # First-boot: show progress until init finishes (or fails).
+    if first_boot_active; then first_boot_screen; continue; fi
+
     items=()
     if is_live; then
         items+=( install "Install Airwaves OS to an internal disk" )
@@ -224,18 +366,26 @@ while true; do
     items+=( reboot   "Reboot" )
     items+=( poweroff "Power off" )
 
-    choice="$(dialog --backtitle "${BT}" --no-cancel --title "Airwaves OS Console" \
-        --menu "$(header)\n" 24 76 9 "${items[@]}" 3>&1 1>&2 2>&3)" || { sleep 1; continue; }
+    # Banner box (kept on screen) above the action menu (#22). --keep-window
+    # retains the infobox while the menu takes input; --begin stacks them.
+    choice="$(dlg --backtitle "${BT}" --no-collapse --keep-window \
+        --begin 1 1 --no-shadow --infobox \
+"$(banner_art)
+$(id_lines)$(stack_line)" 12 76 \
+        --and-widget --keep-window --no-shadow --no-cancel \
+        --begin 13 1 --title "Airwaves OS Console" \
+        --menu "Select an action:" 11 76 7 "${items[@]}" \
+        3>&1 1>&2 2>&3)" || { sleep 1; continue; }
 
     case "$choice" in
         install)  clear; "$FIRSTRUN" --install || true ;;
         config)   configuration_menu ;;
         upgrade)  apply_update upgrade ;;
-        repair)   dialog --backtitle "$BT" --defaultno \
+        repair)   dlg --backtitle "$BT" --defaultno \
                       --yesno "\nRepair re-pulls and recreates the app containers (no version change). Continue?" 9 62 \
                       && apply_update repair ;;
         shell)    open_shell ;;
-        reboot)   dialog --backtitle "$BT" --defaultno --yesno "\nReboot now?" 7 36 && { clear; systemctl reboot; } ;;
-        poweroff) dialog --backtitle "$BT" --defaultno --yesno "\nPower off now?" 7 36 && { clear; systemctl poweroff; } ;;
+        reboot)   dlg --backtitle "$BT" --defaultno --yesno "\nReboot now?" 7 36 && { clear; systemctl reboot; } ;;
+        poweroff) dlg --backtitle "$BT" --defaultno --yesno "\nPower off now?" 7 36 && { clear; systemctl poweroff; } ;;
     esac
 done

--- a/armbian/userpatches/extensions/airwaves-os/scripts/airwaves-tui
+++ b/armbian/userpatches/extensions/airwaves-os/scripts/airwaves-tui
@@ -23,6 +23,9 @@ API="http://localhost/api/v1"                         # manager API via the gate
 VERSIONS="/etc/airwaves/.versions.json"
 RELEASE="/etc/airwaves-release"
 FIRSTRUN_MARKER="/opt/airwaves/.needs-first-run"
+TRIGGER="/run/airwaves/auto-install.json"     # armed by airwaves-preconfig (AWCFG)
+INSTALL="/opt/airwaves/scripts/airwaves-install"
+ISTATUS="/etc/airwaves/install/status.json"
 BT="Airwaves OS"
 export TERM="${TERM:-linux}"
 
@@ -347,10 +350,80 @@ $(id_lines)
     sleep 2
 }
 
+# ---- unattended / self-install (armed by airwaves-preconfig from AWCFG) -----
+# Perform a config-driven install with a countdown the operator can cancel. On
+# success, power off (USB) or reboot (SD self-install). On cancel/failure, remove
+# the trigger and fall back to the menu. The actual erase is gated by the
+# installer's AIRWAVES_INSTALL_APPLY=1, set only after this confirmation.
+run_unattended_install() {
+    local target ab cfg mode post args rc state err
+    target="$(jq -r '.target // empty' "$TRIGGER" 2>/dev/null)"
+    ab="$(jq -r '.ab // false' "$TRIGGER" 2>/dev/null)"
+    cfg="$(jq -r '.config // empty' "$TRIGGER" 2>/dev/null)"
+    mode="$(jq -r '.mode // empty' "$TRIGGER" 2>/dev/null)"
+    post="$(jq -r '.post_install // "poweroff"' "$TRIGGER" 2>/dev/null)"
+    [ -n "$target" ] || { rm -f "$TRIGGER"; return 1; }
+
+    # Defense in depth: re-validate the target is an available internal disk.
+    if ! "$INSTALL" --list-json 2>/dev/null | jq -e --arg d "$target" 'any(.[]; .device==$d)' >/dev/null 2>&1; then
+        rm -f "$TRIGGER"
+        msg "Unattended install" "\nConfigured target ${target} is not an available internal disk.\n\nUsing the menu instead." 11 62
+        return 1
+    fi
+
+    dlg --backtitle "$BT" --title "Unattended install (from AWCFG config)" --pause \
+        "\nThe config partition requests an UNATTENDED install to:\n\n    ${target}\n\nTHIS WILL ERASE ${target}.\nCancel now to use the menu instead." 15 64 8 \
+        || { rm -f "$TRIGGER"; return 1; }
+
+    rm -f "$ISTATUS" 2>/dev/null || true
+    args=(--target "$target")
+    [ "$ab" = "true" ] && args+=(--ab)
+    [ -n "$cfg" ] && [ -f "$cfg" ] && args+=(--config "$cfg")
+    AIRWAVES_INSTALL_APPLY=1 "$INSTALL" "${args[@]}" >/var/log/airwaves-install.log 2>&1 &
+    local pid=$!
+    (
+        local pct phase
+        while kill -0 "$pid" 2>/dev/null; do
+            pct="$(jq -r '.percent // 0' "$ISTATUS" 2>/dev/null || echo 0)"
+            phase="$(jq -r '.phase // "working"' "$ISTATUS" 2>/dev/null || echo working)"
+            echo "XXX"; echo "${pct:-0}"; printf 'Installing to %s\nStep: %s\n' "$target" "$phase"; echo "XXX"
+            sleep 2
+        done
+        echo 100
+    ) | dlg --backtitle "$BT" --title "Unattended install" --gauge "\nPreparing..." 12 64 0
+    wait "$pid"; rc=$?
+    state="$(jq -r '.state // "unknown"' "$ISTATUS" 2>/dev/null || echo unknown)"
+
+    if [ "$rc" -eq 0 ] && [ "$state" = "success" ]; then
+        rm -f "$TRIGGER"
+        # Anti-loop: a self-install from a fixed SD/eMMC marks the SOURCE done so a
+        # re-boot from it won't reinstall.
+        [ "$mode" = "sd-self-install" ] && touch /opt/airwaves/.initialized 2>/dev/null || true
+        systemctl stop airwaves-containers.service 2>/dev/null || true
+        docker compose -f /etc/airwaves/docker-compose.yml down --timeout 10 2>/dev/null || true
+        sync; sync
+        if [ "$post" = "reboot" ]; then
+            dlg --backtitle "$BT" --title "Installed" --infobox "\nInstall complete. Rebooting into ${target}..." 7 56
+            sleep 2; clear; systemctl reboot
+        else
+            dlg --backtitle "$BT" --title "Installed" --msgbox "\nInstall complete.\n\nThe device will POWER OFF. Remove the install media,\nthen power on to boot ${target}." 12 64
+            clear; echo "Powering off..."; mount -o remount,ro / 2>/dev/null || true; systemctl poweroff
+        fi
+        return 0
+    fi
+
+    err="$(jq -r '.error // "see /var/log/airwaves-install.log"' "$ISTATUS" 2>/dev/null)"
+    rm -f "$TRIGGER"
+    msg "Unattended install failed" "\nState: ${state}\n\n${err}\n\nUsing the interactive menu." 13 66
+    return 1
+}
+
 command -v dialog >/dev/null 2>&1 || { echo "dialog not available; opening a shell."; exec bash -l; }
 init_theme
 
 while true; do
+    # Config-driven install armed by airwaves-preconfig (AWCFG). Do it first.
+    if [ -f "$TRIGGER" ]; then run_unattended_install; continue; fi
     # First-boot: show progress until init finishes (or fails).
     if first_boot_active; then first_boot_screen; continue; fi
 

--- a/armbian/userpatches/extensions/airwaves-os/scripts/airwaves-tui
+++ b/armbian/userpatches/extensions/airwaves-os/scripts/airwaves-tui
@@ -85,11 +85,19 @@ primary_ip() {
         [ -n "$tmp" ] && { printf '%s' "$tmp"; return; }
     done
 }
-is_live() {
+# Live = running off the USB installer, NOT an installed disk. With the live-boot
+# (toram) image the root is an overlay/tmpfs in RAM, so we can't key off the root
+# block device being removable; detect the live-boot environment instead. (Falls
+# back to the removable-root check for any non-live-boot live media.)
+is_live_boot() {
+    grep -qw 'boot=live' /proc/cmdline 2>/dev/null && return 0
+    [ -d /run/live/medium ] && return 0
+    case "$(findmnt -no FSTYPE / 2>/dev/null)" in overlay|tmpfs|aufs) return 0 ;; esac
     local rd
     rd="$(lsblk -ndo pkname "$(findmnt -no SOURCE / 2>/dev/null)" 2>/dev/null)"
-    [ "$(cat "/sys/block/${rd}/removable" 2>/dev/null || echo 0)" = "1" ]
+    [ -n "$rd" ] && [ "$(cat "/sys/block/${rd}/removable" 2>/dev/null || echo 0)" = "1" ]
 }
+is_live() { is_live_boot; }
 # Bounded: on first boot dockerd is busy loading images, so an unbounded
 # `docker inspect` could block the menu for minutes. Cap it.
 svc() {

--- a/armbian/userpatches/extensions/airwaves-os/scripts/airwaves-tui
+++ b/armbian/userpatches/extensions/airwaves-os/scripts/airwaves-tui
@@ -120,6 +120,36 @@ stack_line() {
     up="$(awk '{d=int($1/86400);h=int(($1%86400)/3600);m=int(($1%3600)/60); if(d)printf "%dd %dh %dm",d,h,m; else if(h)printf "%dh %dm",h,m; else printf "%dm",m}' /proc/uptime 2>/dev/null)"
     printf '  manager: %s   gateway: %s   ·   uptime: %s\n' "$(svc airwaves-manager)" "$(svc airwaves-gateway)" "${up:-?}"
 }
+# Center a whole block by its widest line, padding every line equally — preserves
+# internal alignment (ASCII art would shear if each line were centered alone).
+center_block() {
+    local w="$1" max=0 len pad; local -a lines=(); local line
+    while IFS= read -r line; do lines+=("$line"); len=${#line}; [ "$len" -gt "$max" ] && max="$len"; done
+    pad=$(( (w - max) / 2 )); [ "$pad" -lt 0 ] && pad=0
+    for line in "${lines[@]}"; do printf '%*s%s\n' "$pad" '' "$line"; done
+}
+# Center each input line independently to width $1 (for single-line details).
+center_lines() {
+    local w="$1" line len pad
+    while IFS= read -r line; do
+        len=${#line}; pad=$(( (w - len) / 2 )); [ "$pad" -lt 0 ] && pad=0
+        printf '%*s%s\n' "$pad" '' "$line"
+    done
+}
+# Console dimensions. A framebuffer console (x86 monitor) can be far wider/taller
+# than 80x25, so we can't rely on dialog auto-centering a multi-widget stack —
+# we compute a centered origin ourselves.
+scr_cols() { local c; c="$(tput cols 2>/dev/null)"; { [ -n "$c" ] && [ "$c" -gt 0 ] 2>/dev/null; } && echo "$c" || echo 80; }
+scr_rows() { local r; r="$(tput lines 2>/dev/null)"; { [ -n "$r" ] && [ "$r" -gt 0 ] 2>/dev/null; } && echo "$r" || echo 25; }
+# Echo "<row> <col>" to top-left-anchor a stack of total height $1, width $2 so it
+# sits centered on the console.
+center_origin() {
+    local h="$1" w="$2" rows cols r c
+    rows="$(scr_rows)"; cols="$(scr_cols)"
+    r=$(( (rows - h) / 2 )); [ "$r" -lt 0 ] && r=0
+    c=$(( (cols - w) / 2 )); [ "$c" -lt 0 ] && c=0
+    echo "$r $c"
+}
 
 # ---- generic dialogs -------------------------------------------------------
 msg()  { dlg --backtitle "${BT}" --title "$1" --msgbox "$2" "${3:-10}" "${4:-64}"; }
@@ -334,19 +364,26 @@ first_boot_active() {
     [ -f "$FIRSTRUN_MARKER" ] && ! systemctl is-failed --quiet airwaves-init.service 2>/dev/null
 }
 first_boot_screen() {
-    local step
+    local step splash
     step="$(journalctl -u airwaves-init.service -o cat --no-pager 2>/dev/null | awk 'NF' | tail -1)"
     step="${step#\[airwaves-init\] }"
     [ -n "$step" ] || step="Starting first-boot setup..."
-    dlg --backtitle "${BT}" --no-collapse --title "Setting up Airwaves OS" --infobox \
-"$(banner_art)
-$(id_lines)
+    # Banner (centered as a block) + details (each line centered) form the splash
+    # ABOVE the box; the first-boot status goes INSIDE the titled box below.
+    splash="$( { banner_art | center_block 74; printf '\n'; id_lines | sed 's/^  *//' | center_lines 74; } )"
+    local oy ox
+    read -r oy ox < <(center_origin 20 78)   # 11 (splash) + 9 (status) = 20 high
+    dlg --backtitle "${BT}" --no-collapse --keep-window \
+        --begin "${oy}" "${ox}" --no-shadow --infobox "${splash}" 11 78 \
+        --and-widget --keep-window --no-shadow \
+        --begin "$((oy + 11))" "${ox}" --title "Setting up Airwaves OS" --infobox \
+"
   First boot — preparing your device. This happens only once.
 
   > ${step}
 
   Loading the app stack from the on-board copy (no network needed).
-  The console menu appears automatically when ready." 20 78
+  The console menu appears automatically when ready." 9 78
     sleep 2
 }
 
@@ -440,13 +477,14 @@ while true; do
     items+=( poweroff "Power off" )
 
     # Banner box (kept on screen) above the action menu (#22). --keep-window
-    # retains the infobox while the menu takes input; --begin stacks them.
+    # retains the infobox while the menu takes input; --begin stacks them. The
+    # banner is centered as a block; the detail/status lines are each centered.
+    splash="$( { banner_art | center_block 74; { id_lines; stack_line; } | sed 's/^  *//' | center_lines 74; } )"
+    read -r oy ox < <(center_origin 23 76)   # 12 (banner) + 11 (menu) = 23 high
     choice="$(dlg --backtitle "${BT}" --no-collapse --keep-window \
-        --begin 1 1 --no-shadow --infobox \
-"$(banner_art)
-$(id_lines)$(stack_line)" 12 76 \
+        --begin "${oy}" "${ox}" --no-shadow --infobox "${splash}" 12 76 \
         --and-widget --keep-window --no-shadow --no-cancel \
-        --begin 13 1 --title "Airwaves OS Console" \
+        --begin "$((oy + 12))" "${ox}" --title "Airwaves OS Console" \
         --menu "Select an action:" 11 76 7 "${items[@]}" \
         3>&1 1>&2 2>&3)" || { sleep 1; continue; }
 

--- a/armbian/userpatches/extensions/airwaves-os/scripts/airwaves-tui
+++ b/armbian/userpatches/extensions/airwaves-os/scripts/airwaves-tui
@@ -30,10 +30,13 @@ BT="Airwaves OS"
 export TERM="${TERM:-linux}"
 
 # A black/cyan dialog theme so the console reads as a branded appliance screen
-# (the banner box and menu share one cohesive black background). Written to
-# tmpfs at startup; falls back to the stock theme if it can't be created.
+# (the banner box and menu share one cohesive black background). Prefer the
+# shipped shared theme (also used by airwaves-firstrun so the installer matches);
+# fall back to writing it to tmpfs, then to the stock theme.
+SHARED_RC="/opt/airwaves/config/dialogrc"
 AWRC="/run/airwaves-tui.dialogrc"
 init_theme() {
+    if [ -r "$SHARED_RC" ]; then AWRC="$SHARED_RC"; return; fi
     cat > "$AWRC" 2>/dev/null <<'RC' || { AWRC="/dev/null"; return; }
 use_shadow = OFF
 use_colors = ON
@@ -115,10 +118,15 @@ id_lines() {
     printf '  Host: %s' "$host"; [ -n "$ip" ] && printf '    IP: %s' "$ip"; printf '\n'
     printf '  Web UI: http://%s.local' "$host"; [ -n "$ip" ] && printf '   /   http://%s' "$ip"; printf '\n'
 }
-stack_line() {
+# Services listed vertically under a header (left-aligned as a block; the caller
+# centers the block). Columns align via printf width.
+services_block() {
     local up
     up="$(awk '{d=int($1/86400);h=int(($1%86400)/3600);m=int(($1%3600)/60); if(d)printf "%dd %dh %dm",d,h,m; else if(h)printf "%dh %dm",h,m; else printf "%dm",m}' /proc/uptime 2>/dev/null)"
-    printf '  manager: %s   gateway: %s   ·   uptime: %s\n' "$(svc airwaves-manager)" "$(svc airwaves-gateway)" "${up:-?}"
+    printf 'Services\n'
+    printf '  %-9s %s\n' "manager:" "$(svc airwaves-manager)"
+    printf '  %-9s %s\n' "gateway:" "$(svc airwaves-gateway)"
+    printf '  %-9s %s\n' "uptime:"  "${up:-?}"
 }
 # Center a whole block by its widest line, padding every line equally — preserves
 # internal alignment (ASCII art would shear if each line were centered alone).
@@ -479,13 +487,15 @@ while true; do
     # Banner box (kept on screen) above the action menu (#22). --keep-window
     # retains the infobox while the menu takes input; --begin stacks them. The
     # banner is centered as a block; the detail/status lines are each centered.
-    splash="$( { banner_art | center_block 74; { id_lines; stack_line; } | sed 's/^  *//' | center_lines 74; } )"
-    read -r oy ox < <(center_origin 23 76)   # 12 (banner) + 11 (menu) = 23 high
+    # Banner (block-centered) + details (line-centered) + a vertical Services
+    # list (block-centered so its column stays aligned).
+    splash="$( { banner_art | center_block 74; id_lines | sed 's/^  *//' | center_lines 74; services_block | center_block 74; } )"
+    read -r oy ox < <(center_origin 24 76)   # 14 (banner) + 10 (menu) = 24 high
     choice="$(dlg --backtitle "${BT}" --no-collapse --keep-window \
-        --begin "${oy}" "${ox}" --no-shadow --infobox "${splash}" 12 76 \
+        --begin "${oy}" "${ox}" --no-shadow --infobox "${splash}" 14 76 \
         --and-widget --keep-window --no-shadow --no-cancel \
-        --begin "$((oy + 12))" "${ox}" --title "Airwaves OS Console" \
-        --menu "Select an action:" 11 76 7 "${items[@]}" \
+        --begin "$((oy + 14))" "${ox}" --title "Airwaves OS Console" \
+        --menu "Select an action:" 10 76 6 "${items[@]}" \
         3>&1 1>&2 2>&3)" || { sleep 1; continue; }
 
     case "$choice" in

--- a/containers/airwaves-manager/src/adapters/host.rs
+++ b/containers/airwaves-manager/src/adapters/host.rs
@@ -6,6 +6,7 @@ use crate::ports::HostPort;
 /// Services the manager is allowed to restart on the host.
 const ALLOWED_SERVICES: &[&str] = &[
     "avahi-daemon",
+    "NetworkManager",
     "systemd-networkd",
     "systemd-resolved",
     "docker",
@@ -95,6 +96,27 @@ impl HostAdapter {
         .await
         .ok()
         .flatten()
+    }
+
+    /// Run an `nmcli` subcommand on the host and capture stdout (None on
+    /// failure). argv[0] is hard-coded to "nmcli", so callers only supply
+    /// subargs and this can never be coerced into running another binary.
+    /// Args are passed as discrete argv (never a shell string), so SSID /
+    /// password values cannot inject commands.
+    pub async fn nmcli_capture(&self, args: &[&str]) -> Option<String> {
+        let mut full = Vec::with_capacity(args.len() + 1);
+        full.push("nmcli".to_string());
+        full.extend(args.iter().map(|s| s.to_string()));
+        self.run_capture(full).await
+    }
+
+    /// Run an `nmcli` subcommand on the host, mapping a non-zero exit to an
+    /// error. Same argv[0]="nmcli" constraint as [`nmcli_capture`].
+    pub async fn nmcli_run(&self, args: &[&str]) -> Result<(), AppError> {
+        let mut full = Vec::with_capacity(args.len() + 1);
+        full.push("nmcli".to_string());
+        full.extend(args.iter().map(|s| s.to_string()));
+        self.run(full).await
     }
 
     /// Count upgradable apt packages on the host (best-effort, uses cached

--- a/containers/airwaves-manager/src/handlers/wifi.rs
+++ b/containers/airwaves-manager/src/handlers/wifi.rs
@@ -1,11 +1,13 @@
+use axum::extract::State;
 use axum::Json;
 use serde::{Deserialize, Serialize};
 
-use crate::AppError;
+use crate::{AppError, AppState};
 
 #[derive(Debug, Serialize)]
 pub struct WifiNetwork {
     pub ssid: String,
+    /// Signal quality as a 0-100 percentage (nmcli's SIGNAL), not dBm.
     pub signal: i32,
     pub security: String,
     pub frequency: String,
@@ -21,12 +23,50 @@ pub struct WifiStatus {
     pub interface: String,
 }
 
-/// Get current WiFi status
 fn is_simulated() -> bool {
-    std::env::var("SIMULATE_HARDWARE").map(|v| v == "true" || v == "1").unwrap_or(false)
+    std::env::var("SIMULATE_HARDWARE")
+        .map(|v| v == "true" || v == "1")
+        .unwrap_or(false)
 }
 
-pub async fn get_status() -> Result<Json<WifiStatus>, AppError> {
+/// Split one `nmcli --terse` line into fields, honoring nmcli's backslash
+/// escaping (`\:` is a literal colon inside a value, `\\` a literal backslash).
+fn split_terse(line: &str) -> Vec<String> {
+    let mut fields = Vec::new();
+    let mut cur = String::new();
+    let mut chars = line.chars();
+    while let Some(c) = chars.next() {
+        match c {
+            '\\' => match chars.next() {
+                Some(n) => cur.push(n),
+                None => cur.push('\\'),
+            },
+            ':' => fields.push(std::mem::take(&mut cur)),
+            _ => cur.push(c),
+        }
+    }
+    fields.push(cur);
+    fields
+}
+
+/// Find the first Wi-Fi device and its connection state from
+/// `nmcli -t -f DEVICE,TYPE,STATE device status`.
+async fn wifi_device(state: &AppState) -> Option<(String, String)> {
+    let out = state
+        .host
+        .nmcli_capture(&["-t", "-f", "DEVICE,TYPE,STATE", "device", "status"])
+        .await?;
+    for line in out.lines() {
+        let f = split_terse(line);
+        if f.len() >= 3 && f[1] == "wifi" {
+            return Some((f[0].clone(), f[2].clone()));
+        }
+    }
+    None
+}
+
+/// Get current Wi-Fi status.
+pub async fn get_status(State(state): State<AppState>) -> Result<Json<WifiStatus>, AppError> {
     if is_simulated() {
         return Ok(Json(WifiStatus {
             enabled: true,
@@ -37,118 +77,130 @@ pub async fn get_status() -> Result<Json<WifiStatus>, AppError> {
         }));
     }
 
-    let iface = find_wifi_interface();
+    let (iface, dev_state) = match wifi_device(&state).await {
+        Some(v) => v,
+        // No Wi-Fi hardware present.
+        None => {
+            return Ok(Json(WifiStatus {
+                enabled: false,
+                connected: false,
+                ssid: None,
+                ip: None,
+                interface: String::new(),
+            }))
+        }
+    };
 
-    if iface.is_none() {
-        return Ok(Json(WifiStatus {
-            enabled: false,
-            connected: false,
-            ssid: None,
-            ip: None,
-            interface: String::new(),
-        }));
-    }
+    let enabled = state
+        .host
+        .nmcli_capture(&["-t", "radio", "wifi"])
+        .await
+        .map(|s| s.trim() == "enabled")
+        .unwrap_or(false);
 
-    let iface = iface.unwrap();
+    // SSID of the active AP on this interface.
+    let ssid = state
+        .host
+        .nmcli_capture(&["-t", "-f", "ACTIVE,SSID", "device", "wifi", "list", "ifname", &iface])
+        .await
+        .and_then(|out| {
+            out.lines().find_map(|l| {
+                let f = split_terse(l);
+                if f.len() >= 2 && f[0] == "yes" && !f[1].is_empty() {
+                    Some(f[1].clone())
+                } else {
+                    None
+                }
+            })
+        });
 
-    // Check connection status via iw
-    let connected_ssid = get_connected_ssid(&iface);
-    let ip = get_interface_ip(&iface);
+    // IPv4 address (strip the /prefix). nmcli prints `IP4.ADDRESS[1]:1.2.3.4/24`.
+    let ip = state
+        .host
+        .nmcli_capture(&["-t", "-f", "IP4.ADDRESS", "device", "show", &iface])
+        .await
+        .and_then(|out| {
+            out.lines().find_map(|l| {
+                let f = split_terse(l);
+                if f.len() >= 2 && f[0].starts_with("IP4.ADDRESS") && !f[1].is_empty() {
+                    Some(f[1].split('/').next().unwrap_or(&f[1]).to_string())
+                } else {
+                    None
+                }
+            })
+        });
+
+    let connected = ssid.is_some() || dev_state.starts_with("connected");
 
     Ok(Json(WifiStatus {
-        enabled: true,
-        connected: connected_ssid.is_some(),
-        ssid: connected_ssid,
+        enabled,
+        connected,
+        ssid,
         ip,
         interface: iface,
     }))
 }
 
-/// Scan for available WiFi networks
-pub async fn scan_networks() -> Result<Json<Vec<WifiNetwork>>, AppError> {
+/// Scan for available Wi-Fi networks.
+pub async fn scan_networks(
+    State(state): State<AppState>,
+) -> Result<Json<Vec<WifiNetwork>>, AppError> {
     if is_simulated() {
         return Ok(Json(vec![
-            WifiNetwork { ssid: "AirwavesNet".to_string(), signal: -35, security: "WPA2".to_string(), frequency: "2.4 GHz".to_string(), connected: false },
-            WifiNetwork { ssid: "HomeWiFi-5G".to_string(), signal: -52, security: "WPA2".to_string(), frequency: "5 GHz".to_string(), connected: false },
-            WifiNetwork { ssid: "Neighbor_Guest".to_string(), signal: -68, security: "WPA2".to_string(), frequency: "2.4 GHz".to_string(), connected: false },
-            WifiNetwork { ssid: "CoffeeShop".to_string(), signal: -75, security: "Open".to_string(), frequency: "2.4 GHz".to_string(), connected: false },
+            WifiNetwork { ssid: "AirwavesNet".to_string(), signal: 92, security: "WPA2".to_string(), frequency: "2.4 GHz".to_string(), connected: false },
+            WifiNetwork { ssid: "HomeWiFi-5G".to_string(), signal: 74, security: "WPA2".to_string(), frequency: "5 GHz".to_string(), connected: false },
+            WifiNetwork { ssid: "Neighbor_Guest".to_string(), signal: 55, security: "WPA2".to_string(), frequency: "2.4 GHz".to_string(), connected: false },
+            WifiNetwork { ssid: "CoffeeShop".to_string(), signal: 40, security: "".to_string(), frequency: "2.4 GHz".to_string(), connected: false },
         ]));
     }
 
-    let iface = find_wifi_interface()
-        .ok_or_else(|| AppError::NotFound("No WiFi interface found".to_string()))?;
-
-    let connected_ssid = get_connected_ssid(&iface);
-
-    // Trigger scan
-    let _ = std::process::Command::new("iw")
-        .args(["dev", &iface, "scan", "trigger"])
-        .output();
-
-    // Wait briefly for scan to complete
-    std::thread::sleep(std::time::Duration::from_secs(2));
-
-    // Get scan results
-    let output = std::process::Command::new("iw")
-        .args(["dev", &iface, "scan", "dump"])
-        .output()
-        .map_err(|e| AppError::Internal(format!("WiFi scan failed: {}", e)))?;
-
-    let stdout = String::from_utf8_lossy(&output.stdout);
-    let mut networks = Vec::new();
-    let mut current_ssid = String::new();
-    let mut current_signal: i32 = -100;
-    let mut current_freq = String::new();
-    let mut current_security = "Open".to_string();
-
-    for line in stdout.lines() {
-        let trimmed = line.trim();
-
-        if trimmed.starts_with("BSS ") {
-            // Save previous network
-            if !current_ssid.is_empty() {
-                networks.push(WifiNetwork {
-                    connected: connected_ssid.as_deref() == Some(&current_ssid),
-                    ssid: std::mem::take(&mut current_ssid),
-                    signal: current_signal,
-                    frequency: std::mem::take(&mut current_freq),
-                    security: std::mem::take(&mut current_security),
-                });
-            }
-            current_signal = -100;
-            current_security = "Open".to_string();
-        } else if trimmed.starts_with("SSID: ") {
-            current_ssid = trimmed[6..].to_string();
-        } else if trimmed.starts_with("signal: ") {
-            current_signal = trimmed
-                .split_whitespace()
-                .nth(1)
-                .and_then(|s| s.parse().ok())
-                .unwrap_or(-100);
-        } else if trimmed.starts_with("freq: ") {
-            let freq_mhz: u32 = trimmed[6..].trim().parse().unwrap_or(0);
-            current_freq = if freq_mhz > 5000 { "5 GHz".to_string() } else { "2.4 GHz".to_string() };
-        } else if trimmed.contains("WPA") || trimmed.contains("RSN") {
-            current_security = if trimmed.contains("WPA2") || trimmed.contains("RSN") {
-                "WPA2".to_string()
-            } else {
-                "WPA".to_string()
-            };
-        }
+    // Ensure there is Wi-Fi hardware before asking NM to scan.
+    if wifi_device(&state).await.is_none() {
+        return Err(AppError::NotFound("No Wi-Fi interface found".to_string()));
     }
 
-    // Push last network
-    if !current_ssid.is_empty() {
+    let out = state
+        .host
+        .nmcli_capture(&[
+            "-t",
+            "-f",
+            "ACTIVE,SSID,SIGNAL,SECURITY,FREQ",
+            "device",
+            "wifi",
+            "list",
+            "--rescan",
+            "yes",
+        ])
+        .await
+        .ok_or_else(|| AppError::Internal("Wi-Fi scan failed (nmcli)".to_string()))?;
+
+    let mut networks = Vec::new();
+    for line in out.lines() {
+        let f = split_terse(line);
+        if f.len() < 5 {
+            continue;
+        }
+        let ssid = f[1].clone();
+        if ssid.is_empty() {
+            continue; // hidden network
+        }
+        let signal: i32 = f[2].trim().parse().unwrap_or(0);
+        let security = {
+            let s = f[3].trim();
+            if s.is_empty() { "Open".to_string() } else { s.to_string() }
+        };
+        let freq_mhz: u32 = f[4].split_whitespace().next().and_then(|s| s.parse().ok()).unwrap_or(0);
+        let frequency = if freq_mhz >= 5000 { "5 GHz".to_string() } else { "2.4 GHz".to_string() };
         networks.push(WifiNetwork {
-            connected: connected_ssid.as_deref() == Some(&current_ssid),
-            ssid: current_ssid,
-            signal: current_signal,
-            frequency: current_freq,
-            security: current_security,
+            ssid,
+            signal,
+            security,
+            frequency,
+            connected: f[0] == "yes",
         });
     }
 
-    // Sort by signal strength (strongest first), deduplicate by SSID
+    // Strongest first, then keep one entry per SSID (drops band/BSS duplicates).
     networks.sort_by(|a, b| b.signal.cmp(&a.signal));
     networks.dedup_by(|a, b| a.ssid == b.ssid);
 
@@ -161,92 +213,52 @@ pub struct ConnectRequest {
     pub password: Option<String>,
 }
 
-/// Connect to a WiFi network
-pub async fn connect(Json(req): Json<ConnectRequest>) -> Result<Json<serde_json::Value>, AppError> {
-    let iface = find_wifi_interface()
-        .ok_or_else(|| AppError::NotFound("No WiFi interface found".to_string()))?;
-
-    // Write wpa_supplicant config
-    let wpa_config = if let Some(ref psk) = req.password {
-        format!(
-            "network={{\n    ssid=\"{}\"\n    psk=\"{}\"\n    key_mgmt=WPA-PSK\n}}\n",
-            req.ssid, psk
-        )
-    } else {
-        format!(
-            "network={{\n    ssid=\"{}\"\n    key_mgmt=NONE\n}}\n",
-            req.ssid
-        )
-    };
-
-    // Write network config for systemd-networkd
-    let network_config = format!(
-        "[Match]\nName={}\n\n[Network]\nDHCP=yes\n",
-        iface
-    );
-
-    std::fs::write(format!("/etc/wpa_supplicant/wpa_supplicant-{}.conf", iface), &wpa_config)
-        .map_err(|e| AppError::Internal(format!("Failed to write wpa config: {}", e)))?;
-
-    std::fs::write(format!("/etc/systemd/network/20-{}.network", iface), &network_config)
-        .map_err(|e| AppError::Internal(format!("Failed to write network config: {}", e)))?;
-
-    // Restart networking
-    let _ = std::process::Command::new("systemctl")
-        .args(["restart", &format!("wpa_supplicant@{}", iface)])
-        .output();
-    let _ = std::process::Command::new("systemctl")
-        .args(["restart", "systemd-networkd"])
-        .output();
-
-    Ok(Json(serde_json::json!({
-        "status": "connecting",
-        "ssid": req.ssid,
-        "interface": iface,
-    })))
+/// Reject SSID / passphrase values with control characters (NUL/newline etc.).
+/// Args go to nmcli as discrete argv (no shell), so this is belt-and-suspenders.
+fn clean_field(v: &str) -> bool {
+    !v.is_empty() && v.len() <= 256 && !v.chars().any(|c| c.is_control())
 }
 
-// ---- Helpers ----
-
-fn find_wifi_interface() -> Option<String> {
-    let net_dir = std::path::Path::new("/sys/class/net");
-    if let Ok(entries) = std::fs::read_dir(net_dir) {
-        for entry in entries.flatten() {
-            let name = entry.file_name().to_string_lossy().to_string();
-            // Check if it's a wireless interface
-            if entry.path().join("wireless").exists() || name.starts_with("wl") {
-                return Some(name);
-            }
+/// Connect to a Wi-Fi network via NetworkManager. NM creates/updates the
+/// connection profile and brings up DHCP; it persists across reboots.
+pub async fn connect(
+    State(state): State<AppState>,
+    Json(req): Json<ConnectRequest>,
+) -> Result<Json<serde_json::Value>, AppError> {
+    if !clean_field(&req.ssid) {
+        return Err(AppError::BadRequest("Invalid SSID".to_string()));
+    }
+    if let Some(ref psk) = req.password {
+        if !psk.is_empty() && !clean_field(psk) {
+            return Err(AppError::BadRequest("Invalid password".to_string()));
         }
     }
-    None
-}
 
-fn get_connected_ssid(iface: &str) -> Option<String> {
-    std::process::Command::new("iw")
-        .args(["dev", iface, "link"])
-        .output()
-        .ok()
-        .and_then(|output| {
-            let stdout = String::from_utf8_lossy(&output.stdout);
-            stdout
-                .lines()
-                .find(|l| l.trim().starts_with("SSID:"))
-                .map(|l| l.trim()[6..].to_string())
-        })
-}
+    // Make sure Wi-Fi hardware exists and the radio is on before connecting.
+    if wifi_device(&state).await.is_none() {
+        return Err(AppError::NotFound("No Wi-Fi interface found".to_string()));
+    }
+    let _ = state.host.nmcli_run(&["radio", "wifi", "on"]).await;
 
-fn get_interface_ip(iface: &str) -> Option<String> {
-    std::process::Command::new("ip")
-        .args(["-4", "-j", "addr", "show", iface])
-        .output()
-        .ok()
-        .and_then(|output| {
-            serde_json::from_slice::<serde_json::Value>(&output.stdout).ok()
-        })
-        .and_then(|json| {
-            json.as_array()?.first()?["addr_info"]
-                .as_array()?.first()?["local"]
-                .as_str().map(String::from)
-        })
+    let result = match req.password.as_deref().filter(|p| !p.is_empty()) {
+        Some(psk) => {
+            state
+                .host
+                .nmcli_run(&["device", "wifi", "connect", &req.ssid, "password", psk])
+                .await
+        }
+        None => {
+            state
+                .host
+                .nmcli_run(&["device", "wifi", "connect", &req.ssid])
+                .await
+        }
+    };
+
+    result.map_err(|e| AppError::Internal(format!("Failed to connect to '{}': {e}", req.ssid)))?;
+
+    Ok(Json(serde_json::json!({
+        "status": "connected",
+        "ssid": req.ssid,
+    })))
 }

--- a/docs/AB-UPDATES.md
+++ b/docs/AB-UPDATES.md
@@ -25,6 +25,11 @@ Two **equal** root slots (so either can receive any future image) + one shared
 - **Rockchip rk3588**: raw 0–16 MiB reserved for u-boot (unchanged) · `p1 rootA(16M→,aw-root-a)` · `p2 rootB(aw-root-b)` · `p3 data(aw-data)`
 - **Raspberry Pi bcm2711**: **dual firmware** so a bad kernel can't brick both slots · `p1 fwA(FAT32,256M,AW-FW-A)` · `p2 rootA(aw-root-a)` · `p3 fwB(FAT32,256M,AW-FW-B)` · `p4 rootB(aw-root-b)` · `p5 data(aw-data)`
 
+All installer layouts (single-root and A/B) also append a small **`AWCFG`**
+FAT32 config partition (~100 MiB) as the **last** partition — the offline
+provisioning / headless-recovery surface. It is inert on a running system unless
+first-setup or an `apply.conf` trigger is present. See `docs/PRECONFIG.md`.
+
 ## Data model
 
 `aw-data` holds everything that must survive a slot swap; each root is otherwise

--- a/docs/PRECONFIG.md
+++ b/docs/PRECONFIG.md
@@ -1,0 +1,80 @@
+# Airwaves OS — config partition (AWCFG) & unattended install
+
+Every Airwaves OS image (and every installed system) carries a small FAT32
+partition labelled **AWCFG** holding `airwaves-install.json`. You can edit it on
+any computer (Windows/macOS/Linux). It is the offline, headless provisioning and
+recovery surface. The manager API / web UI remains the primary way to configure a
+running device; AWCFG is for when there's no screen or no network yet.
+
+## When the config is read
+
+`airwaves-preconfig` (a systemd oneshot that runs before the app stack) reads
+AWCFG and applies it:
+
+1. **First setup** — automatically, on the very first boot of a freshly flashed
+   or freshly installed system.
+2. **Later, on a running system** — only if a file named **`apply.conf`** is also
+   present on AWCFG. It applies once, then deletes `apply.conf`.
+
+On a normal boot of an already-set-up device with no `apply.conf`, AWCFG is
+ignored.
+
+### Headless Wi-Fi recovery (the common case)
+
+A flashed device whose Wi-Fi didn't connect, with no screen attached:
+
+1. Power off, remove the SD/USB, mount AWCFG on another computer.
+2. Edit the `wifi` block in `airwaves-install.json`.
+3. Create an empty file named `apply.conf` next to it.
+4. Re-insert, power on. It reconnects, and `apply.conf` is consumed.
+
+## `airwaves-install.json`
+
+```jsonc
+{
+  "hostname": "airwaves-tower-1",          // RFC1123; blank = derive from MAC
+  "wifi":    { "ssid": "MyNet", "psk": "secret" },  // blank ssid = skip
+  "channel": "stable",                     // stable|beta|dev; blank = unchanged
+  "timezone": "America/Chicago",           // blank = unchanged
+  "ssh_keys": ["ssh-ed25519 AAAA... me"],  // added to root + airwaves
+
+  // --- unattended install (DESTRUCTIVE; OFF by default) ---
+  "auto_install": false,        // install with no menu (live USB / removable)
+  "confirm_destructive": false, // REQUIRED with auto_install/self_install
+  "target": "auto",             // "auto" (exactly one internal disk) | "largest" | "/dev/nvme0n1"
+  "ab": false,                  // A/B (blue/green) layout; needs >= 12 GiB
+  "self_install": false,        // flashed SD -> install to internal eMMC/NVMe (ARM)
+  "post_install": "poweroff"    // "poweroff" (USB) or "reboot" (SD self-install)
+}
+```
+
+Fields map onto the running system: `hostname` -> `config.json` `.device.hostname`
++ `hostnamectl`; `wifi` -> a NetworkManager connection; `channel` ->
+`.versions.json`; `timezone` -> `timedatectl`; `ssh_keys` -> `authorized_keys`.
+
+## Unattended install — safety model
+
+Installing erases a disk, so the gate is strict:
+
+- **Dual key:** nothing is erased unless **both** `auto_install` (or
+  `self_install`) **and** `confirm_destructive` are `true`.
+- **Target validation:** the target is resolved against the list of *internal,
+  non-removable* disks, and the **source/boot disk is never a candidate**.
+  `"auto"` requires *exactly one* candidate; anything ambiguous, missing, or
+  invalid **falls back to the interactive installer and erases nothing**.
+- **Cancelable:** the console shows a countdown before any write; cancel returns
+  to the menu.
+- **No loop:** the trigger lives in tmpfs; a successful SD->eMMC self-install
+  marks the source so re-booting it won't reinstall. The installed target ships
+  with the destructive flags forced off.
+
+`auto_install` is for a removable live USB; `self_install` is for an ARM board
+booted from a flashed SD card that should move itself onto internal storage.
+
+## Build / flashing notes
+
+- The AWCFG partition is the **last** partition and **survives `dd`-flash**. Use
+  `dd`, Balena Etcher (>= 1.18), or Raspberry Pi Imager (>= 1.8); older imagers
+  that truncate trailing partitions will drop it.
+- The Wi-Fi PSK is stored in plain text on a FAT partition (no encryption). Keep
+  the card physically secure, or clear `psk` after the device has connected.


### PR DESCRIPTION
Hardware-feedback pass on the x86/ARM appliance experience: make first boot work **offline**, switch the network stack to **NetworkManager**, rebrand the **console**, and add the **AWCFG** config partition with config-driven / unattended install.

> Not yet hardware-validated — needs a `Build OS Image (Simple)` run + flash. ARM SD→eMMC self-install specifically needs Rock 5B/OPi5 testing before relying on it.

## Offline first boot
- CI bundles the release's manager+gateway images (per `releases/stable.json`, right CPU arch) into `/opt/airwaves/images/*.tar`; `airwaves-init` loads them with no network and pins compose to the matching tag.
- **Bug fix:** `airwaves-init.service` ran `Before=docker.service` but needs docker — it aborted before loading containers, so offline first boot died. Now `After`/`Requires=docker`, `Before=airwaves-containers`.

## NetworkManager
- `airwaves-networking.sh` installs/enables NetworkManager, masks `systemd-networkd`, keeps NM off docker/veth/bridge, and masks the `*-wait-online` units (removes the ~1-2 min offline-boot delay).
- Manager `wifi.rs` rewritten to drive `nmcli` on the host via `HostAdapter` (constrained helpers; validated SSID/PSK). `WifiNetwork.signal` is now 0–100% (nmcli), not dBm.

## Console (tty1 TUI)
- Branded black/cyan theme; banner in its own box above the menu.
- First-boot status screen (shows the current init step) instead of a half-working menu.
- Config uses the manager API when up; when it's down, a **warned local rescue** path (Wi-Fi via `nmcli` at minimum, plus hostname/channel).

## AWCFG config partition + config-driven install (#24)
A FAT32 `AWCFG` partition (last partition; survives `dd`-flash; editable on any OS) on every image **and** every install target. `airwaves-preconfig` reads it on first setup, or on a running system only when an `apply.conf` trigger is present (then applies once and deletes it).
- **Headless Wi-Fi recovery:** edit `airwaves-install.json`, drop `apply.conf`, reboot.
- **Unattended install** (dual-key gate: `auto_install` + `confirm_destructive`): target validated against the internal-disk list (never the source/removable disk; `"auto"` requires exactly one), cancelable countdown, fail-safe to the interactive menu.
- **SD→eMMC self-install** on ARM with an anti-reinstall-loop guard.
- AWCFG added to all four installer target layouts (x86 single, x86 A/B, u-boot, Pi); seeded with a sanitized config (destructive flags forced off); first-boot markers reset so the target re-inits.
- Interactive installs now prompt for hostname + optional Wi-Fi.
- Docs: `docs/PRECONFIG.md` (deployer guide + safety model), `docs/AB-UPDATES.md` AWCFG note.

## Review
Two adversarial review passes over the disk-touching code caught and fixed: a **critical** (every GPT image would've shipped a corrupted partition table), a **high** (formatter could've wiped the ESP), the A/B grub-install fallback gap, and a source-disk-resolution safety hole. All bash/shellcheck/`cargo check` clean; 41/41 manager tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Offline-first container bundling/staging to reduce first-boot registry pulls (when enabled during image builds).
  * Added AWCFG FAT32 config partition with declarative `airwaves-preconfig` provisioning from `airwaves-install.json` and one-time `apply.conf` triggering (hostname, Wi‑Fi, channel, timezone, SSH keys; safer unattended install).
  * Upgraded Airwaves TUI with branded dialogs, improved manager-aware setup, and streamlined first-boot/unattended install flows.

* **Infrastructure / System Changes**
  * Standardized networking on NetworkManager and masked systemd-networkd to avoid boot blocking.

* **Documentation**
  * Expanded AWCFG/preconfig and A/B layout guidance, including headless recovery notes and `airwaves-install.json` examples.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->